### PR TITLE
Change comment in docs compilation script

### DIFF
--- a/doc/watch.sh
+++ b/doc/watch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script compiles the document as soon as all the .tex files in the project are updated.
+# This script compiles the document as soon as all the .md files in the project are updated.
 # In debian-based distros, it needs inotify-tools and (optionally) libnotify-bin
 
 inotifywait -m -e create ./ | while read dir event file; do


### PR DESCRIPTION
The current comment says that the docs generation script (/docs/watch.sh) watch for changes to .tex files. It actually listen on changes to .md. Presumably the extension were changed to .md so Github will display the docs.

I'll admit that this is pedantry. Feel free to reject if you don't give a damn :-)
I came accross it while reading the docs and wondering why there were variables in them.