### PR TITLE
Separate workflow for gas test

### DIFF
--- a/.github/workflows/gas.yaml
+++ b/.github/workflows/gas.yaml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/setup-node@v1
 
     - name: Install Ganache
-      run: npm install -g ganache-cli@6.9.1
+      run: npm install -g ganache-cli@6.10.1
 
     - name: Setup Python 3.8
       uses: actions/setup-python@v1

--- a/.github/workflows/gas.yaml
+++ b/.github/workflows/gas.yaml
@@ -1,0 +1,34 @@
+on:
+  push:
+    branches:
+      - master
+
+name: gas efficiency workflow
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+
+  gas:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v1
+
+    - name: Install Ganache
+      run: npm install -g ganache-cli@6.9.1
+
+    - name: Setup Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+
+    - name: Install Requirements
+      run: pip install -r requirements.txt
+
+    - name: Run Tests
+      run: brownie test tests/test_scalability.py --gas

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -52,26 +52,3 @@ jobs:
 
     - name: Run Tests
       run: brownie test tests/integration -n auto
-
-  gas:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v1
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-
-    - name: Install Ganache
-      run: npm install -g ganache-cli@6.9.1
-
-    - name: Setup Python 3.8
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.8
-
-    - name: Install Requirements
-      run: pip install -r requirements.txt
-
-    - name: Run Tests
-      run: brownie test tests/test_scalability.py --gas

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/setup-node@v1
 
     - name: Install Ganache
-      run: npm install -g ganache-cli@6.9.1
+      run: npm install -g ganache-cli@6.10.1
 
     - name: Setup Python 3.8
       uses: actions/setup-python@v1
@@ -40,7 +40,7 @@ jobs:
       uses: actions/setup-node@v1
 
     - name: Install Ganache
-      run: npm install -g ganache-cli@6.9.1
+      run: npm install -g ganache-cli@6.10.1
 
     - name: Setup Python 3.8
       uses: actions/setup-python@v1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-eth-brownie>=1.10.2,<2.0.0
+eth-brownie>=1.10.5,<2.0.0
 vyper==0.2.3


### PR DESCRIPTION
The `gas` job in the CI takes upwards of an hour to run. This PR modifies the workflow so that this job only runs on new commits to `master`.