### PR TITLE
Updates to LiquidityGauge and LiquidityGaugeReward

### DIFF
--- a/contracts/LiquidityGauge.vy
+++ b/contracts/LiquidityGauge.vy
@@ -202,13 +202,13 @@ def user_checkpoint(addr: address) -> bool:
 
 
 @external
-def claimable_tokens() -> uint256:
+def claimable_tokens(addr: address) -> uint256:
     """
     @notice Claimable number of tokens per-user
             This function should be manually changed to "view" in the ABI
     """
-    self._checkpoint(msg.sender)
-    return self.integrate_fraction[msg.sender]
+    self._checkpoint(addr)
+    return self.integrate_fraction[addr]
 
 
 @external

--- a/contracts/LiquidityGauge.vy
+++ b/contracts/LiquidityGauge.vy
@@ -198,7 +198,7 @@ def user_checkpoint(addr: address) -> bool:
     assert (msg.sender == addr) or (msg.sender == self.minter)  # dev: unauthorized
     self._checkpoint(addr)
     self._update_liquidity_limit(addr, self.balanceOf[addr], self.totalSupply)
-    return True  # XXX explain
+    return True
 
 
 @external

--- a/contracts/LiquidityGaugeReward.vy
+++ b/contracts/LiquidityGaugeReward.vy
@@ -239,7 +239,7 @@ def user_checkpoint(addr: address) -> bool:
     assert (msg.sender == addr) or (msg.sender == self.minter)  # dev: unauthorized
     self._checkpoint(addr)
     self._update_liquidity_limit(addr, self.balanceOf[addr], self.totalSupply)
-    return True  # XXX explain
+    return True
 
 
 @external
@@ -254,11 +254,7 @@ def claimable_tokens(addr: address) -> uint256:
 
 @external
 @view
-def claimable_reward(_addr: address = ZERO_ADDRESS) -> uint256:
-    addr: address = msg.sender
-    if _addr != ZERO_ADDRESS:
-        addr = msg.sender
-
+def claimable_reward(addr: address) -> uint256:
     d_reward: uint256 = CurveRewards(self.reward_contract).earned(self)
 
     user_balance: uint256 = self.balanceOf[addr]

--- a/contracts/LiquidityGaugeReward.vy
+++ b/contracts/LiquidityGaugeReward.vy
@@ -329,17 +329,7 @@ def withdraw(_value: uint256):
 
 @external
 @nonreentrant('lock')
-def claim_rewards():
-    self._checkpoint(msg.sender)
-    _rewards_for: uint256 = self.rewards_for[msg.sender]
-    assert ERC20(self.rewarded_token).transfer(
-        msg.sender, _rewards_for - self.claimed_rewards_for[msg.sender])
-    self.claimed_rewards_for[msg.sender] = _rewards_for
-
-
-@external
-@nonreentrant('lock')
-def claim_rewards_for(addr: address):
+def claim_rewards(addr: address = msg.sender):
     self._checkpoint_rewards(addr)
     _rewards_for: uint256 = self.rewards_for[addr]
     assert ERC20(self.rewarded_token).transfer(

--- a/contracts/LiquidityGaugeReward.vy
+++ b/contracts/LiquidityGaugeReward.vy
@@ -243,13 +243,13 @@ def user_checkpoint(addr: address) -> bool:
 
 
 @external
-def claimable_tokens() -> uint256:
+def claimable_tokens(addr: address) -> uint256:
     """
     @notice Claimable number of tokens per-user
             This function should be manually changed to "view" in the ABI
     """
-    self._checkpoint(msg.sender)
-    return self.integrate_fraction[msg.sender]
+    self._checkpoint(addr)
+    return self.integrate_fraction[addr]
 
 
 @external

--- a/tests/unitary/LiquidityGaugeReward/test_claim_rewards.py
+++ b/tests/unitary/LiquidityGaugeReward/test_claim_rewards.py
@@ -1,3 +1,4 @@
+import pytest
 from tests.conftest import approx
 
 REWARD = 10 ** 20
@@ -5,37 +6,8 @@ WEEK = 7 * 86400
 LP_AMOUNT = 10 ** 18
 
 
-def test_claim_no_deposit(accounts, chain, liquidity_gauge_reward, mock_lp_token,
-                          reward_contract, coin_reward):
-    # Fund
-    coin_reward._mint_for_testing(REWARD, {'from': accounts[0]})
-    coin_reward.transfer(reward_contract, REWARD, {'from': accounts[0]})
-    reward_contract.notifyRewardAmount(REWARD, {'from': accounts[0]})
-
-    chain.sleep(WEEK)
-
-    liquidity_gauge_reward.claim_rewards({'from': accounts[1]})
-
-    assert coin_reward.balanceOf(accounts[1]) == 0
-
-
-def test_claim_no_rewards(accounts, chain, liquidity_gauge_reward, mock_lp_token,
-                          reward_contract, coin_reward):
-    # Deposit
-    mock_lp_token.transfer(accounts[1], LP_AMOUNT, {'from': accounts[0]})
-    mock_lp_token.approve(liquidity_gauge_reward, LP_AMOUNT, {'from': accounts[1]})
-    liquidity_gauge_reward.deposit(LP_AMOUNT, {'from': accounts[1]})
-
-    chain.sleep(WEEK)
-
-    liquidity_gauge_reward.withdraw(LP_AMOUNT, {'from': accounts[1]})
-    liquidity_gauge_reward.claim_rewards({'from': accounts[1]})
-
-    assert coin_reward.balanceOf(accounts[1]) == 0
-
-
-def test_claim_one_lp(accounts, chain, liquidity_gauge_reward, mock_lp_token,
-                      reward_contract, coin_reward):
+@pytest.fixture(scope="module", autouse=True)
+def initial_setup(accounts, coin_reward, reward_contract, mock_lp_token, liquidity_gauge_reward):
     # Fund
     coin_reward._mint_for_testing(REWARD, {'from': accounts[0]})
     coin_reward.transfer(reward_contract, REWARD, {'from': accounts[0]})
@@ -46,6 +18,8 @@ def test_claim_one_lp(accounts, chain, liquidity_gauge_reward, mock_lp_token,
     mock_lp_token.approve(liquidity_gauge_reward, LP_AMOUNT, {'from': accounts[1]})
     liquidity_gauge_reward.deposit(LP_AMOUNT, {'from': accounts[1]})
 
+
+def test_claim_one_lp(accounts, chain, liquidity_gauge_reward, coin_reward):
     chain.sleep(WEEK)
 
     liquidity_gauge_reward.withdraw(LP_AMOUNT, {'from': accounts[1]})
@@ -56,20 +30,35 @@ def test_claim_one_lp(accounts, chain, liquidity_gauge_reward, mock_lp_token,
     assert approx(REWARD, reward, 1.001 / WEEK)  # ganache-cli jitter of 1 s
 
 
+def test_claim_for_other(accounts, chain, liquidity_gauge_reward, coin_reward):
+    chain.sleep(WEEK)
+
+    liquidity_gauge_reward.withdraw(LP_AMOUNT, {'from': accounts[1]})
+    liquidity_gauge_reward.claim_rewards(accounts[1], {'from': accounts[2]})
+
+    assert coin_reward.balanceOf(accounts[2]) == 0
+
+    reward = coin_reward.balanceOf(accounts[1])
+    assert reward <= REWARD
+    assert approx(REWARD, reward, 1.001 / WEEK)  # ganache-cli jitter of 1 s
+
+
+def test_claim_for_other_no_reward(accounts, chain, liquidity_gauge_reward, coin_reward):
+    chain.sleep(WEEK)
+
+    liquidity_gauge_reward.withdraw(LP_AMOUNT, {'from': accounts[1]})
+    liquidity_gauge_reward.claim_rewards(accounts[2], {'from': accounts[1]})
+
+    assert coin_reward.balanceOf(accounts[1]) == 0
+    assert coin_reward.balanceOf(accounts[2]) == 0
+
+
 def test_claim_two_lp(accounts, chain, liquidity_gauge_reward, mock_lp_token,
-                      reward_contract, coin_reward, no_call_coverage):
-    # Fund
-    coin_reward._mint_for_testing(REWARD, {'from': accounts[0]})
-    coin_reward.transfer(reward_contract, REWARD, {'from': accounts[0]})
-    reward_contract.notifyRewardAmount(REWARD, {'from': accounts[0]})
+                      coin_reward, no_call_coverage):
 
     # Deposit
     mock_lp_token.approve(liquidity_gauge_reward, LP_AMOUNT, {'from': accounts[0]})
     liquidity_gauge_reward.deposit(LP_AMOUNT, {'from': accounts[0]})
-
-    mock_lp_token.transfer(accounts[1], LP_AMOUNT, {'from': accounts[0]})
-    mock_lp_token.approve(liquidity_gauge_reward, LP_AMOUNT, {'from': accounts[1]})
-    liquidity_gauge_reward.deposit(LP_AMOUNT, {'from': accounts[1]})
 
     chain.sleep(WEEK)
 
@@ -80,7 +69,7 @@ def test_claim_two_lp(accounts, chain, liquidity_gauge_reward, mock_lp_token,
         rewards += [coin_reward.balanceOf(accounts[i])]
 
     # Calculate rewards
-    claimable_rewards = [liquidity_gauge_reward.claimable_reward({'from': acc})
+    claimable_rewards = [liquidity_gauge_reward.claimable_reward(acc, {'from': acc})
                          for acc in accounts[:2]]
 
     # Calculation == results

--- a/tests/unitary/LiquidityGaugeReward/test_claim_rewards_none.py
+++ b/tests/unitary/LiquidityGaugeReward/test_claim_rewards_none.py
@@ -1,0 +1,32 @@
+
+REWARD = 10 ** 20
+WEEK = 7 * 86400
+LP_AMOUNT = 10 ** 18
+
+
+def test_claim_no_deposit(accounts, chain, liquidity_gauge_reward, reward_contract, coin_reward):
+    # Fund
+    coin_reward._mint_for_testing(REWARD, {'from': accounts[0]})
+    coin_reward.transfer(reward_contract, REWARD, {'from': accounts[0]})
+    reward_contract.notifyRewardAmount(REWARD, {'from': accounts[0]})
+
+    chain.sleep(WEEK)
+
+    liquidity_gauge_reward.claim_rewards({'from': accounts[1]})
+
+    assert coin_reward.balanceOf(accounts[1]) == 0
+
+
+def test_claim_no_rewards(accounts, chain, liquidity_gauge_reward, mock_lp_token,
+                          reward_contract, coin_reward):
+    # Deposit
+    mock_lp_token.transfer(accounts[1], LP_AMOUNT, {'from': accounts[0]})
+    mock_lp_token.approve(liquidity_gauge_reward, LP_AMOUNT, {'from': accounts[1]})
+    liquidity_gauge_reward.deposit(LP_AMOUNT, {'from': accounts[1]})
+
+    chain.sleep(WEEK)
+
+    liquidity_gauge_reward.withdraw(LP_AMOUNT, {'from': accounts[1]})
+    liquidity_gauge_reward.claim_rewards({'from': accounts[1]})
+
+    assert coin_reward.balanceOf(accounts[1]) == 0


### PR DESCRIPTION
### What I did
* adjust `claimable_tokens` to accept an address as an input argument, instead of using `msg.sender`
* remove default arg for `claimable_rewards`
* merge `claim_rewards` and `claim_rewards_for` using default args
* expand test cases