### PR TITLE
Updates to VestingEscrow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -51,4 +51,4 @@ jobs:
       run: pip install -r requirements.txt
 
     - name: Run Tests
-      run: brownie test tests/integration -n auto --failfast
+      run: brownie test tests/integration -n auto --failfast --durations 5

--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -1,3 +1,8 @@
 reports:
   exclude_paths:
     - contracts/testing/*.*
+
+networks:
+    development:
+      cmd_settings:
+        accounts: 100

--- a/contracts/VestingEscrow.vy
+++ b/contracts/VestingEscrow.vy
@@ -42,15 +42,25 @@ disabled_at: public(HashMap[address, uint256])
 admin: public(address)
 future_admin: public(address)
 
+fund_admins_enabled: public(bool)
+fund_admins: public(HashMap[address, bool])
+
 
 @external
-def __init__(_token: address, _start_time: uint256, _end_time: uint256, _can_disable: bool):
+def __init__(
+    _token: address,
+    _start_time: uint256,
+    _end_time: uint256,
+    _can_disable: bool,
+    _fund_admins: address[4]
+):
     """
     @param _token Address of the ERC20 token being distributed
     @param _start_time Timestamp at which the distribution starts. Should be in
         the future, so that we have enough time to VoteLock everyone
     @param _end_time Time until everything should be vested
     @param _can_disable Whether admin can disable accounts in this deployment
+    @param _fund_admins Temporary admin accounts used only for funding
     """
     assert _start_time >= block.timestamp
     assert _end_time > _start_time
@@ -60,6 +70,9 @@ def __init__(_token: address, _start_time: uint256, _end_time: uint256, _can_dis
     self.start_time = _start_time
     self.end_time = _end_time
     self.can_disable = _can_disable
+    self.fund_admins_enabled = True
+    for addr in _fund_admins:
+        self.fund_admins[addr] = True
 
 
 
@@ -71,14 +84,15 @@ def fund(_recipients: address[100], _amounts: uint256[100]):
     @param _recipients List of addresses to fund
     @param _amounts Amount of vested tokens for each address
     """
-    assert msg.sender == self.admin  # dev: admin only
+    if msg.sender != self.admin:
+        assert self.fund_admins[msg.sender]  # dev: admin only
+        assert self.fund_admins_enabled  # dev: fund admins disabled
 
-    # Transfer tokens for all of the recipients here
     _total_amount: uint256 = 0
     for i in range(100):
         amount: uint256 = _amounts[i]
         recipient: address = _recipients[i]
-        if amount == 0:
+        if recipient == ZERO_ADDRESS:
             break
         _total_amount += amount
         self.initial_locked[recipient] += amount
@@ -116,6 +130,15 @@ def disable_can_disable():
     """
     assert msg.sender == self.admin  # dev: admin only
     self.can_disable = False
+
+
+@external
+def disable_fund_admins():
+    """
+    @notice Disable the funding admin accounts
+    """
+    assert msg.sender == self.admin  # dev: admin only
+    self.fund_admins_enabled = False
 
 
 @internal

--- a/contracts/VestingEscrow.vy
+++ b/contracts/VestingEscrow.vy
@@ -65,7 +65,7 @@ def __init__(_token: address, _start_time: uint256, _end_time: uint256, _can_dis
 
 @external
 @nonreentrant('lock')
-def fund(_recipients: address[10], _amounts: uint256[10]):
+def fund(_recipients: address[100], _amounts: uint256[100]):
     """
     @notice Add vested tokens for multiple recipients
     @param _recipients List of addresses to fund
@@ -75,20 +75,17 @@ def fund(_recipients: address[10], _amounts: uint256[10]):
 
     # Transfer tokens for all of the recipients here
     _total_amount: uint256 = 0
-    for i in range(10):
-        if _recipients[i] == ZERO_ADDRESS:
+    for i in range(100):
+        amount: uint256 = _amounts[i]
+        recipient: address = _recipients[i]
+        if amount == 0:
             break
-        _total_amount += _amounts[i]
+        _total_amount += amount
+        self.initial_locked[recipient] += amount
+        log Fund(recipient, amount)
+
     self.initial_locked_supply += _total_amount
     assert ERC20(self.token).transferFrom(msg.sender, self, _total_amount)  # dev: transfer failed
-
-    # Create individual records
-    for i in range(10):
-        if _recipients[i] == ZERO_ADDRESS:
-            break
-        self.initial_locked[_recipients[i]] += _amounts[i]
-
-        log Fund(_recipients[i], _amounts[i])
 
 
 @external

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,7 +102,7 @@ def start_time(chain):
 
 @pytest.fixture(scope="module")
 def end_time(start_time):
-    yield start_time + 100000
+    yield start_time + 100000000
 
 
 @pytest.fixture(scope="module")
@@ -124,11 +124,11 @@ def vesting_factory(VestingEscrowFactory, accounts, vesting_target):
 
 
 @pytest.fixture(scope="module")
-def vesting_simple(VestingEscrowSimple, accounts, vesting_factory, coin_a, start_time, end_time):
+def vesting_simple(VestingEscrowSimple, accounts, vesting_factory, coin_a, start_time):
     coin_a._mint_for_testing(10**21, {'from': accounts[0]})
     coin_a.transfer(vesting_factory, 10**21, {'from': accounts[0]})
     tx = vesting_factory.deploy_vesting_contract(
-        coin_a, accounts[1], 10**20, start_time, end_time, True, {'from': accounts[0]}
+        coin_a, accounts[1], 10**20, True, 100000000, start_time, {'from': accounts[0]}
     )
     yield VestingEscrowSimple.at(tx.new_contracts[0])
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,7 +107,7 @@ def end_time(start_time):
 
 @pytest.fixture(scope="module")
 def vesting(VestingEscrow, accounts, coin_a, start_time, end_time):
-    contract = VestingEscrow.deploy(coin_a, start_time, end_time, True, {'from': accounts[0]})
+    contract = VestingEscrow.deploy(coin_a, start_time, end_time, True, accounts[1:5], {'from': accounts[0]})
     coin_a._mint_for_testing(10**21, {'from': accounts[0]})
     coin_a.approve(contract, 10**21, {'from': accounts[0]})
     yield contract

--- a/tests/integration/LiquidityGauge/test_deposits_withdrawals.py
+++ b/tests/integration/LiquidityGauge/test_deposits_withdrawals.py
@@ -108,4 +108,4 @@ def test_state_machine(state_machine, accounts, liquidity_gauge, mock_lp_token, 
     # because this is a simple state machine, we use more steps than normal
     settings = {"stateful_step_count": 25}
 
-    state_machine(StateMachine, accounts, liquidity_gauge, mock_lp_token, settings=settings)
+    state_machine(StateMachine, accounts[:5], liquidity_gauge, mock_lp_token, settings=settings)

--- a/tests/integration/LiquidityGaugeReward/test_rewards_total.py
+++ b/tests/integration/LiquidityGaugeReward/test_rewards_total.py
@@ -132,4 +132,4 @@ def test_state_machine(
     # because this is a simple state machine, we use more steps than normal
     settings = {"stateful_step_count": 25}
 
-    state_machine(StateMachine, accounts, liquidity_gauge_reward, mock_lp_token, reward_contract, coin_reward, settings=settings)
+    state_machine(StateMachine, accounts[:5], liquidity_gauge_reward, mock_lp_token, reward_contract, coin_reward, settings=settings)

--- a/tests/integration/VestingEscrow/test_claim_partial.py
+++ b/tests/integration/VestingEscrow/test_claim_partial.py
@@ -6,8 +6,9 @@ ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 
 @pytest.fixture(scope="module", autouse=True)
 def initial_funding(vesting, accounts):
-    recipients = [accounts[1]] + [ZERO_ADDRESS] * 9
-    vesting.fund(recipients, [10**20] + [0] * 9, {'from': accounts[0]})
+    vesting.add_tokens(10**21, {'from': accounts[0]})
+    recipients = [accounts[1]] + [ZERO_ADDRESS] * 99
+    vesting.fund(recipients, [10**20] + [0] * 99, {'from': accounts[0]})
 
 
 @given(sleep_time=strategy("uint", max_value=100000))

--- a/tests/integration/VotingEscrow/test_deposit_withdraw_voting.py
+++ b/tests/integration/VotingEscrow/test_deposit_withdraw_voting.py
@@ -10,7 +10,7 @@ GAS_LIMIT = 4_000_000
 class StateMachine:
 
     # account to perform a deposit / withdrawal from
-    st_account = strategy('address')
+    st_account = strategy('address', length=10)
 
     # amount to deposit / withdraw
     st_value = strategy('uint64')
@@ -172,4 +172,4 @@ def test_state_machine(state_machine, accounts, ERC20, VotingEscrow):
         token, 'Voting-escrowed CRV', 'veCRV', 'veCRV_0.99', {'from': accounts[0]}
     )
 
-    state_machine(StateMachine, accounts, token, voting_escrow)
+    state_machine(StateMachine, accounts[:10], token, voting_escrow)

--- a/tests/unitary/VestingEscrow/test_claim.py
+++ b/tests/unitary/VestingEscrow/test_claim.py
@@ -47,10 +47,14 @@ def test_claim_partial(vesting, coin_a, accounts, chain, start_time, end_time):
     assert vesting.total_claimed(accounts[1]) == expected_amount
 
 
-def test_claim_multiple(vesting, coin_a, accounts, chain, start_time):
+def test_claim_multiple(vesting, coin_a, accounts, chain, start_time, end_time):
     chain.sleep(start_time - chain.time() - 1000)
+    balance = 0
     for i in range(11):
-        chain.sleep(10000)
+        chain.sleep((end_time - start_time) // 10)
         vesting.claim({'from': accounts[1]})
+        new_balance = coin_a.balanceOf(accounts[1])
+        assert new_balance > balance
+        balance = new_balance
 
     assert coin_a.balanceOf(accounts[1]) == 10**20

--- a/tests/unitary/VestingEscrow/test_claim.py
+++ b/tests/unitary/VestingEscrow/test_claim.py
@@ -5,8 +5,9 @@ ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 
 @pytest.fixture(scope="module", autouse=True)
 def initial_funding(vesting, accounts):
-    recipients = [accounts[1]] + [ZERO_ADDRESS] * 9
-    vesting.fund(recipients, [10**20] + [0] * 9, {'from': accounts[0]})
+    recipients = [accounts[1]] + [ZERO_ADDRESS] * 99
+    vesting.add_tokens(10**21, {'from': accounts[0]})
+    vesting.fund(recipients, [10**20] + [0] * 99, {'from': accounts[0]})
 
 
 def test_claim_full(vesting, coin_a, accounts, chain, end_time):

--- a/tests/unitary/VestingEscrow/test_disable_and_claim.py
+++ b/tests/unitary/VestingEscrow/test_disable_and_claim.py
@@ -5,8 +5,9 @@ ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 
 @pytest.fixture(scope="module", autouse=True)
 def initial_funding(vesting, accounts):
-    recipients = [accounts[1]] + [ZERO_ADDRESS] * 9
-    vesting.fund(recipients, [10**20] + [0] * 9, {'from': accounts[0]})
+    recipients = [accounts[1]] + [ZERO_ADDRESS] * 99
+    vesting.add_tokens(10**21, {'from': accounts[0]})
+    vesting.fund(recipients, [10**20] + [0] * 99, {'from': accounts[0]})
 
 
 def test_disable_after_end_time(vesting, coin_a, accounts, chain, end_time):

--- a/tests/unitary/VestingEscrow/test_fund.py
+++ b/tests/unitary/VestingEscrow/test_fund.py
@@ -1,85 +1,114 @@
 import brownie
+import pytest
 
 ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+AMOUNTS = [10**17 * i for i in range(1, 101)]
 
 
-def test_balanceOf(vesting, coin_a, accounts):
-    amounts = [10**17 * i for i in range(1, 11)]
-    vesting.fund(accounts[:10], amounts, {'from': accounts[0]})
+@pytest.fixture(scope="module", autouse=True)
+def initial_setup(accounts, vesting):
+    vesting.add_tokens(10**21, {'from': accounts[0]})
 
-    assert coin_a.balanceOf(vesting) == sum(amounts)
-    assert coin_a.balanceOf(accounts[0]) == 10**21 - sum(amounts)
+
+def test_balanceOf(coin_a, vesting):
+    assert coin_a.balanceOf(vesting) == 10**21
 
 
 def test_initial_locked_supply(vesting, accounts):
-    amounts = [10**17 * i for i in range(1, 11)]
-    vesting.fund(accounts[:10], amounts, {'from': accounts[0]})
+    vesting.fund(accounts[:100], AMOUNTS, {'from': accounts[0]})
 
-    assert vesting.initial_locked_supply() == sum(amounts)
+    assert vesting.initial_locked_supply() == sum(AMOUNTS)
+
+
+def test_unallocated_supply(vesting, accounts):
+    vesting.fund(accounts[:100], AMOUNTS, {'from': accounts[0]})
+
+    assert vesting.unallocated_supply() == 10**21 - sum(AMOUNTS)
 
 
 def test_initial_locked(vesting, accounts):
-    amounts = [10**17 * i for i in range(1, 11)]
-    vesting.fund(accounts[:10], amounts, {'from': accounts[0]})
+    vesting.fund(accounts[:100], AMOUNTS, {'from': accounts[0]})
 
-    for acct, expected_amount in zip(accounts, amounts):
+    for acct, expected_amount in zip(accounts, AMOUNTS):
         assert vesting.initial_locked(acct) == expected_amount
 
 
 def test_event(vesting, accounts):
-    amounts = [10**17 * i for i in range(1, 11)]
-    tx = vesting.fund(accounts[:10], amounts, {'from': accounts[0]})
+    tx = vesting.fund(accounts[:100], AMOUNTS, {'from': accounts[0]})
 
-    assert len(tx.events['Fund']) == 10
-    for event, acct, expected_amount in zip(tx.events['Fund'], accounts, amounts):
+    assert len(tx.events['Fund']) == 100
+    for event, acct, expected_amount in zip(tx.events['Fund'], accounts, AMOUNTS):
         assert event.values() == [acct, expected_amount]
 
 
 def test_partial_recipients(vesting, accounts):
-    amounts = [10**17 * i for i in range(1, 11)]
-    vesting.fund(accounts[:5]+[ZERO_ADDRESS]*5, amounts, {'from': accounts[0]})
+    recipients = accounts[:5] + [ZERO_ADDRESS] * (len(AMOUNTS) - 5)
+    vesting.fund(recipients, AMOUNTS, {'from': accounts[0]})
 
-    assert vesting.initial_locked_supply() == sum(amounts[:5])
+    assert vesting.initial_locked_supply() == sum(AMOUNTS[:5])
 
 
 def test_one_recipient(vesting, accounts):
-    recipients = [accounts[5]] + [ZERO_ADDRESS] * 9
-    vesting.fund(recipients, [10**20]+[0]*9, {'from': accounts[0]})
+    recipients = [accounts[5]] + [ZERO_ADDRESS] * 99
+    vesting.fund(recipients, [10**20]+[0]*99, {'from': accounts[0]})
 
     assert vesting.initial_locked_supply() == 10**20
 
 
 def test_multiple_calls_different_recipients(vesting, accounts):
-    recipients = [accounts[5]] + [ZERO_ADDRESS] * 9
-    amounts = [10**20, 10**20 * 2] + [0]*8
+    recipients = [accounts[5]] + [ZERO_ADDRESS] * 99
+    amounts = [10**20, 10**20 * 2] + [0]*98
     vesting.fund(recipients, amounts, {'from': accounts[0]})
 
     recipients[:2] = [accounts[4], accounts[6]]
     vesting.fund(recipients, amounts, {'from': accounts[0]})
 
     assert vesting.initial_locked_supply() == 10**20 * 4
+    assert vesting.unallocated_supply() == 10**21 - (10**20 * 4)
     assert vesting.initial_locked(accounts[4]) == 10**20
     assert vesting.initial_locked(accounts[5]) == 10**20
     assert vesting.initial_locked(accounts[6]) == 10**20 * 2
 
 
 def test_multiple_calls_same_recipient(vesting, accounts):
-    recipients = [accounts[5]] + [ZERO_ADDRESS] * 9
-    amounts = [10**20 * 2] + [0] * 9
+    recipients = [accounts[5]] + [ZERO_ADDRESS] * 99
+    amounts = [10**20 * 2] + [0] * 99
     vesting.fund(recipients, amounts, {'from': accounts[0]})
 
     amounts[0] = 10**20
     vesting.fund(recipients, amounts, {'from': accounts[0]})
 
     assert vesting.initial_locked_supply() == 10**20 * 3
+    assert vesting.unallocated_supply() == 10**21 - (10**20 * 3)
     assert vesting.initial_locked(accounts[5]) == 10**20 * 3
 
 
 def test_admin_only(vesting, accounts):
     with brownie.reverts("dev: admin only"):
-        vesting.fund(accounts[:10], [10**18] * 10, {'from': accounts[1]})
+        vesting.fund(accounts[:100], [10**18] * 100, {'from': accounts[6]})
 
 
-def test_transfer_fails(vesting, accounts):
-    with brownie.reverts("dev: transfer failed"):
-        vesting.fund(accounts[:10], [10**21] * 10, {'from': accounts[0]})
+def test_over_allocation(vesting, accounts):
+    with brownie.reverts("Integer underflow"):
+        vesting.fund(accounts[:100], [10**21 + 1] + [0] * 99, {'from': accounts[0]})
+
+
+@pytest.mark.parametrize("idx", range(1, 5))
+def test_fund_admin(vesting, accounts, idx):
+    recipients = [accounts[5]] + [ZERO_ADDRESS] * 99
+    amounts = [10**20, 10**20 * 2] + [0]*98
+    vesting.fund(recipients, amounts, {'from': accounts[idx]})
+
+    assert vesting.initial_locked_supply() == 10**20
+    assert vesting.unallocated_supply() == 10**21 - 10**20
+    assert vesting.initial_locked(accounts[5]) == 10**20
+
+
+@pytest.mark.parametrize("idx", range(1, 5))
+def test_disabled_fund_admin(vesting, accounts, idx):
+    vesting.disable_fund_admins({'from': accounts[0]})
+
+    recipients = [accounts[5]] + [ZERO_ADDRESS] * 99
+    amounts = [10**20, 10**20 * 2] + [0]*98
+    with brownie.reverts("dev: fund admins disabled"):
+        vesting.fund(recipients, amounts, {'from': accounts[idx]})

--- a/tests/unitary/VestingEscrow/test_getters.py
+++ b/tests/unitary/VestingEscrow/test_getters.py
@@ -1,11 +1,12 @@
 import pytest
 
-amounts = [10**17 * i for i in range(1, 11)]
+amounts = [10**17 * i for i in range(1, 101)]
 
 
 @pytest.fixture(scope="module", autouse=True)
 def initial_funding(vesting, accounts):
-    vesting.fund(accounts[:10], amounts, {'from': accounts[0]})
+    vesting.add_tokens(10**21, {'from': accounts[0]})
+    vesting.fund(accounts[:100], amounts, {'from': accounts[0]})
 
 
 def test_vested_supply(chain, vesting, end_time):

--- a/tests/unitary/VestingEscrowFactory/test_claim_simple.py
+++ b/tests/unitary/VestingEscrowFactory/test_claim_simple.py
@@ -38,10 +38,14 @@ def test_claim_partial(vesting_simple, coin_a, accounts, chain, start_time, end_
     assert vesting_simple.total_claimed(accounts[1]) == expected_amount
 
 
-def test_claim_multiple(vesting_simple, coin_a, accounts, chain, start_time):
+def test_claim_multiple(vesting_simple, coin_a, accounts, chain, start_time, end_time):
     chain.sleep(start_time - chain.time() - 1000)
+    balance = 0
     for i in range(11):
-        chain.sleep(10000)
+        chain.sleep((end_time - start_time) // 10)
         vesting_simple.claim({'from': accounts[1]})
+        new_balance = coin_a.balanceOf(accounts[1])
+        assert new_balance > balance
+        balance = new_balance
 
     assert coin_a.balanceOf(accounts[1]) == 10**20

--- a/tests/unitary/VestingEscrowFactory/test_deploy_escrow.py
+++ b/tests/unitary/VestingEscrowFactory/test_deploy_escrow.py
@@ -10,31 +10,31 @@ def initial_funding(coin_a, vesting_factory, accounts):
     coin_a.transfer(vesting_factory, 10**21, {'from': accounts[0]})
 
 
-def test_admin_only(VestingEscrowSimple, accounts, vesting_factory, coin_a, start_time, end_time):
+def test_admin_only(accounts, vesting_factory, coin_a):
     with brownie.reverts("dev: admin only"):
         vesting_factory.deploy_vesting_contract(
-            coin_a, accounts[1], 10**18, start_time, end_time, True, {'from': accounts[1]}
+            coin_a, accounts[1], 10**18, True, 86400 * 365, {'from': accounts[1]}
         )
 
 
-def test_approve_fail(VestingEscrowSimple, accounts, vesting_factory, coin_a, start_time, end_time):
+def test_approve_fail(accounts, vesting_factory, coin_a):
     with brownie.reverts("dev: approve failed"):
         vesting_factory.deploy_vesting_contract(
-            ZERO_ADDRESS, accounts[1], 10**18, start_time, end_time, True, {'from': accounts[0]}
+            ZERO_ADDRESS, accounts[1], 10**18, True, 86400 * 365, {'from': accounts[0]}
         )
 
 
-def test_start_too_soon(VestingEscrowSimple, accounts, chain, vesting_factory, coin_a, end_time):
+def test_start_too_soon(accounts, chain, vesting_factory, coin_a):
     with brownie.reverts("dev: start time too soon"):
         vesting_factory.deploy_vesting_contract(
-            coin_a, accounts[1], 10**18, chain.time() + 86400 * 364, end_time, True, {'from': accounts[0]}
+            coin_a, accounts[1], 10**18, True, 86400 * 365, chain.time()-1, {'from': accounts[0]}
         )
 
 
-def test_end_before_start(VestingEscrowSimple, accounts, vesting_factory, coin_a, start_time):
-    with brownie.reverts("dev: end before start"):
+def test_duration_too_short(accounts, vesting_factory, coin_a):
+    with brownie.reverts("dev: duration too short"):
         vesting_factory.deploy_vesting_contract(
-            coin_a, accounts[1], 10**18, start_time, start_time - 1, True, {'from': accounts[0]}
+            coin_a, accounts[1], 10**18, True, 86400 * 365 - 1, {'from': accounts[0]}
         )
 
 
@@ -42,13 +42,28 @@ def test_target_is_set(vesting_factory, vesting_target):
     assert vesting_factory.target() == vesting_target
 
 
-def test_deploys(VestingEscrowSimple, accounts, vesting_factory, coin_a, start_time, end_time):
+def test_deploys(accounts, vesting_factory, coin_a):
     tx = vesting_factory.deploy_vesting_contract(
-        coin_a, accounts[1], 10**18, start_time, end_time, True, {'from': accounts[0]}
+        coin_a, accounts[1], 10**18, True, 86400 * 365, {'from': accounts[0]}
     )
 
     assert len(tx.new_contracts) == 1
     assert tx.return_value == tx.new_contracts[0]
+
+
+def test_start_and_duration(VestingEscrowSimple, accounts, chain, vesting_factory, coin_a):
+    start_time = chain.time() + 100
+
+    tx = vesting_factory.deploy_vesting_contract(
+        coin_a, accounts[1], 10**18, True, 86400 * 700, start_time, {'from': accounts[0]}
+    )
+
+    assert len(tx.new_contracts) == 1
+    assert tx.return_value == tx.new_contracts[0]
+
+    escrow = VestingEscrowSimple.at(tx.return_value)
+    assert escrow.start_time() == start_time
+    assert escrow.end_time() == start_time + 86400 * 700
 
 
 def test_token_xfer(vesting_simple, coin_a):


### PR DESCRIPTION
### What I did
* Gas optimizations for `VestingEscrow.fund`
* Increase number of recipients to 100
* Add "funding admins" that can only be used to create new vestings, and are disabled via `disable_fund_admins`
* Separate transfer of tokens from creating vestings using `add_tokens`
* Adjust/fix logic around min vesting duration in `VestingEscrowSimple`
* Update test cases