### PR TITLE
Delayed inflation

### DIFF
--- a/tests/integration/ERC20CRV/test_mint_integration.py
+++ b/tests/integration/ERC20CRV/test_mint_integration.py
@@ -1,10 +1,17 @@
 import brownie
+import pytest
 from brownie.test import strategy, given
 
 from tests.conftest import YEAR
 
 
-@given(duration=strategy('uint', min_value=1, max_value=YEAR))
+@pytest.fixture(scope="module", autouse=True)
+def initial_setup(chain, token):
+    chain.sleep(86401)
+    token.update_mining_parameters()
+
+
+@given(duration=strategy('uint', min_value=86500, max_value=YEAR))
 def test_mint(accounts, chain, token, duration):
     token.set_minter(accounts[0], {'from': accounts[0]})
     creation_time = token.start_epoch_time()
@@ -19,7 +26,7 @@ def test_mint(accounts, chain, token, duration):
     assert token.totalSupply() == initial_supply + amount
 
 
-@given(duration=strategy('uint', min_value=1, max_value=YEAR))
+@given(duration=strategy('uint', min_value=86500, max_value=YEAR))
 def test_overmint(accounts, chain, token, duration):
     token.set_minter(accounts[0], {'from': accounts[0]})
     creation_time = token.start_epoch_time()

--- a/tests/integration/ERC20CRV/test_mintable_in_timeframe.py
+++ b/tests/integration/ERC20CRV/test_mintable_in_timeframe.py
@@ -1,7 +1,14 @@
+import pytest
 from brownie.test import strategy, given
 
 from tests.conftest import approx
 from tests.conftest import YEAR, YEAR_1_SUPPLY, INITIAL_SUPPLY
+
+
+@pytest.fixture(scope="module", autouse=True)
+def initial_setup(chain, token):
+    chain.sleep(86401)
+    token.update_mining_parameters()
 
 
 @given(time=strategy("decimal", min_value=1, max_value=7))

--- a/tests/unitary/ERC20CRV/test_inflation_delay.py
+++ b/tests/unitary/ERC20CRV/test_inflation_delay.py
@@ -1,0 +1,39 @@
+WEEK = 86400 * 7
+YEAR = 365 * 86400
+
+
+def test_rate(accounts, chain, token):
+    assert token.rate() == 0
+
+    chain.sleep(86401)
+    token.update_mining_parameters({'from': accounts[0]})
+
+    assert token.rate() > 0
+
+
+def test_start_epoch_time(accounts, chain, token):
+    creation_time = token.start_epoch_time()
+    assert creation_time == token.tx.timestamp + 86400 - YEAR
+
+    chain.sleep(86401)
+    token.update_mining_parameters({'from': accounts[0]})
+
+    assert token.start_epoch_time() == creation_time + YEAR
+
+
+def test_mining_epoch(accounts, chain, token):
+    assert token.mining_epoch() == -1
+
+    chain.sleep(86401)
+    token.update_mining_parameters({'from': accounts[0]})
+
+    assert token.mining_epoch() == 0
+
+
+def test_available_supply(accounts, chain, token):
+    assert token.available_supply() == 1_272_727_273 * 10**18
+
+    chain.sleep(86401)
+    token.update_mining_parameters({'from': accounts[0]})
+
+    assert token.available_supply() > 1_272_727_273 * 10**18

--- a/tests/unitary/ERC20CRV/test_mint.py
+++ b/tests/unitary/ERC20CRV/test_mint.py
@@ -1,11 +1,18 @@
 import brownie
+import pytest
 
 WEEK = 86400 * 7
 YEAR = 365 * 86400
 ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 
 
-def test_available_supply(chain, web3, token):
+@pytest.fixture(scope="module", autouse=True)
+def initial_setup(chain, token):
+    chain.sleep(86401)
+    token.update_mining_parameters()
+
+
+def test_available_supply(chain, token):
     creation_time = token.start_epoch_time()
     initial_supply = token.totalSupply()
     rate = token.rate()

--- a/tests/unitary/Minter/test_minter.py
+++ b/tests/unitary/Minter/test_minter.py
@@ -41,6 +41,7 @@ def test_mint(accounts, chain, three_gauges, minter, token):
     minter.mint(three_gauges[0], {'from': accounts[1]})
     expected = three_gauges[0].integrate_fraction(accounts[1])
 
+    assert expected > 0
     assert token.balanceOf(accounts[1]) == expected
     assert minter.minted(accounts[1], three_gauges[0]) == expected
 
@@ -138,3 +139,13 @@ def test_mint_wrong_gauge(accounts, chain, three_gauges, minter, token):
 def test_mint_not_a_gauge(accounts, minter):
     with brownie.reverts('dev: gauge is not added'):
         minter.mint(accounts[1], {'from': accounts[0]})
+
+
+def test_mint_before_inflation_begins(accounts, chain, three_gauges, minter, token):
+    three_gauges[0].deposit(1e18, {'from': accounts[1]})
+
+    chain.sleep(token.start_epoch_time() - chain.time() - 5)
+    minter.mint(three_gauges[0], {'from': accounts[1]})
+
+    assert token.balanceOf(accounts[1]) == 0
+    assert minter.minted(accounts[1], three_gauges[0]) == 0


### PR DESCRIPTION
### What I did
Add a delay before inflation of `ERC20CRV` begins.

### How I did it
* The first mining epoch is now `-1` and the rate starts at `0`.
* The initial epoch is set to end one day after employment (modifiable via `INFLATION_DELAY` constant).
* When the epoch changes from `-1` to `0`, the rate is adjusted to `INITIAL_RATE` instead of the usual decay.

This approach lets us delay inflation long enough to deploy all the contracts, and also lets users stake immediately. I have updated the test cases to confirm that minting is still possible during this new `-1` period - however the reward is zero.