### PR TITLE
Ci updates

### DIFF
--- a/.github/workflows/gas.yaml
+++ b/.github/workflows/gas.yaml
@@ -7,6 +7,7 @@ name: gas efficiency workflow
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  NODE_OPTIONS: --max_old_space_size=4096
 
 jobs:
 
@@ -14,16 +15,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+
+    - name: Cache Compiler Installations
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.solcx
+          ~/.vvm
+        key: compiler-cache
 
     - name: Setup Node.js
       uses: actions/setup-node@v1
 
     - name: Install Ganache
-      run: npm install -g ganache-cli@6.10.1
+      run: npm install
 
     - name: Setup Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,6 +4,8 @@ name: main workflow
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  NODE_OPTIONS: --max_old_space_size=4096
+
 
 jobs:
 
@@ -25,7 +27,7 @@ jobs:
       uses: actions/setup-node@v1
 
     - name: Install Ganache
-      run: npm install -g ganache-cli@6.10.1
+      run: npm install
 
     - name: Setup Python 3.8
       uses: actions/setup-python@v2
@@ -56,7 +58,7 @@ jobs:
       uses: actions/setup-node@v1
 
     - name: Install Ganache
-      run: npm install -g ganache-cli@6.10.1
+      run: npm install
 
     - name: Setup Python 3.8
       uses: actions/setup-python@v2
@@ -87,7 +89,7 @@ jobs:
       uses: actions/setup-node@v1
 
     - name: Install Ganache
-      run: npm install -g ganache-cli@6.10.1
+      run: npm install
 
     - name: Setup Python 3.8
       uses: actions/setup-python@v2

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+    "scripts": {
+      "preinstall": "npm i -g ganache-cli@6.11.0"
+    }
+  }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-eth-brownie==1.11.7
+eth-brownie>=1.11.10,<2.0.0

--- a/tests/unitary/VestingEscrowFactory/test_admin_simple.py
+++ b/tests/unitary/VestingEscrowFactory/test_admin_simple.py
@@ -2,12 +2,12 @@ import brownie
 
 
 def test_commit_admin_only(vesting_simple, accounts):
-    with brownie.reverts("dev: admin only"):
+    with brownie.reverts():
         vesting_simple.commit_transfer_ownership(accounts[1], {'from': accounts[1]})
 
 
 def test_apply_admin_only(vesting_simple, accounts):
-    with brownie.reverts("dev: admin only"):
+    with brownie.reverts():
         vesting_simple.apply_transfer_ownership({'from': accounts[1]})
 
 
@@ -26,5 +26,5 @@ def test_apply_transfer_ownership(vesting_simple, accounts):
 
 
 def test_apply_without_commit(vesting_simple, accounts):
-    with brownie.reverts("dev: admin not set"):
+    with brownie.reverts():
         vesting_simple.apply_transfer_ownership({'from': accounts[0]})

--- a/tests/unitary/VestingEscrowFactory/test_deploy_escrow.py
+++ b/tests/unitary/VestingEscrowFactory/test_deploy_escrow.py
@@ -86,7 +86,7 @@ def test_init_vars(vesting_simple, accounts, coin_a, start_time, end_time):
 
 
 def test_cannot_call_init(vesting_simple, accounts, coin_a, start_time, end_time):
-    with brownie.reverts("dev: can only initialize once"):
+    with brownie.reverts():
         vesting_simple.initialize(
             accounts[0],
             coin_a,

--- a/tests/unitary/VestingEscrowFactory/test_disable_simple.py
+++ b/tests/unitary/VestingEscrowFactory/test_disable_simple.py
@@ -4,12 +4,12 @@ ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 
 
 def test_toggle_admin_only(vesting_simple, accounts):
-    with brownie.reverts("dev: admin only"):
+    with brownie.reverts():
         vesting_simple.toggle_disable(accounts[2], {'from': accounts[1]})
 
 
 def test_disable_can_disable_admin_only(vesting_simple, accounts):
-    with brownie.reverts("dev: admin only"):
+    with brownie.reverts():
         vesting_simple.disable_can_disable({'from': accounts[1]})
 
 
@@ -34,7 +34,7 @@ def test_disable_can_disable(vesting_simple, accounts):
     vesting_simple.disable_can_disable({'from': accounts[0]})
     assert vesting_simple.can_disable() is False
 
-    with brownie.reverts("Cannot disable"):
+    with brownie.reverts():
         vesting_simple.toggle_disable(accounts[1], {'from': accounts[0]})
 
 


### PR DESCRIPTION
In the CI...

* add `package.json` to standardize installation of ganache across workflows, bump version to `6.11.0`
* add `NODE_OPTIONS` to CI env vars
* add caching to gas workflow
* bump various actions to `v2`

In the tests, I've removed the revert reason targets in some of the `VestingEscrowSimple` tests.  There is a brownie bug here and the fix for it requires more bandwidth than I can give it right now, so this is a quicker solution to ensure tests pass.

All of this work solves blockers to updating `PoolProxy` for fee distribution, which will be in another PR soon:tm: