### PR TITLE
tokenized wrapper for LiquidityGaugeRewards

### DIFF
--- a/contracts/LiquidityGaugeRewardWrapper.vy
+++ b/contracts/LiquidityGaugeRewardWrapper.vy
@@ -1,0 +1,406 @@
+# @version 0.2.7
+"""
+@title Tokenized Liquidity Gauge Wrapper
+@author Curve Finance
+@license MIT
+@notice Allows tokenized deposits and claiming from `LiquidityGaugeReward`
+"""
+
+from vyper.interfaces import ERC20
+
+implements: ERC20
+
+interface LiquidityGauge:
+    def lp_token() -> address: view
+    def minter() -> address: view
+    def crv_token() -> address: view
+    def rewarded_token() -> address: view
+    def deposit(_value: uint256): nonpayable
+    def withdraw(_value: uint256): nonpayable
+    def claimable_reward(addr: address) -> uint256: view
+    def claimed_rewards_for(addr: address) -> uint256: view
+    def claimable_tokens(addr: address) -> uint256: nonpayable
+    def claim_rewards(): nonpayable
+
+
+interface Minter:
+    def mint(gauge_addr: address): nonpayable
+
+
+event Deposit:
+    provider: indexed(address)
+    value: uint256
+
+event Withdraw:
+    provider: indexed(address)
+    value: uint256
+
+event CommitOwnership:
+    admin: address
+
+event ApplyOwnership:
+    admin: address
+
+event Transfer:
+    _from: indexed(address)
+    _to: indexed(address)
+    _value: uint256
+
+event Approval:
+    _owner: indexed(address)
+    _spender: indexed(address)
+    _value: uint256
+
+
+minter: public(address)
+crv_token: public(address)
+rewarded_token: public(address)
+lp_token: public(address)
+gauge: public(address)
+
+balanceOf: public(HashMap[address, uint256])
+totalSupply: public(uint256)
+allowances: HashMap[address, HashMap[address, uint256]]
+
+name: public(String[64])
+symbol: public(String[32])
+decimals: public(uint256)
+
+# caller -> recipient -> can deposit?
+approved_to_deposit: public(HashMap[address, HashMap[address, bool]])
+
+crv_integral: uint256
+crv_integral_for: HashMap[address, uint256]
+claimable_crv: public(HashMap[address, uint256])
+
+reward_integral: public(uint256)
+reward_integral_for: public(HashMap[address, uint256])
+claimable_rewards: public(HashMap[address, uint256])
+
+admin: public(address)
+future_admin: public(address)
+is_killed: public(bool)
+
+
+@external
+def __init__(
+    _name: String[64],
+    _symbol: String[32],
+    _gauge: address,
+    _admin: address
+):
+    """
+    @notice Contract constructor
+    @param _name Token full name
+    @param _symbol Token symbol
+    @param _gauge Liquidity gauge contract address
+    @param _admin Admin who can kill the gauge
+    """
+    self.name = _name
+    self.symbol = _symbol
+    self.decimals = 18
+
+    lp_token: address = LiquidityGauge(_gauge).lp_token()
+    ERC20(lp_token).approve(_gauge, MAX_UINT256)
+
+    self.minter = LiquidityGauge(_gauge).minter()
+    self.crv_token = LiquidityGauge(_gauge).crv_token()
+    self.rewarded_token = LiquidityGauge(_gauge).rewarded_token()
+    self.lp_token = lp_token
+    self.gauge = _gauge
+    self.admin = _admin
+
+
+@internal
+def _checkpoint(addr: address):
+    gauge: address = self.gauge
+    token: address = self.crv_token
+    total_balance: uint256 = self.totalSupply
+
+    d_reward: uint256 = ERC20(token).balanceOf(self)
+    Minter(self.minter).mint(gauge)
+    d_reward = ERC20(token).balanceOf(self) - d_reward
+
+    dI: uint256 = 0
+    if total_balance > 0:
+        dI = 10 ** 18 * d_reward / total_balance
+    I: uint256 = self.crv_integral + dI
+    self.crv_integral = I
+    self.claimable_crv[addr] += self.balanceOf[addr] * (I - self.crv_integral_for[addr]) / 10 ** 18
+    self.crv_integral_for[addr] = I
+
+    token = self.rewarded_token
+
+    d_reward = ERC20(token).balanceOf(self)
+    LiquidityGauge(gauge).claim_rewards()
+    d_reward = ERC20(token).balanceOf(self) - d_reward
+
+    if total_balance > 0:
+        dI = 10 ** 18 * d_reward / total_balance
+
+    I = self.reward_integral + dI
+    self.reward_integral = I
+    self.claimable_rewards[addr] += self.balanceOf[addr] * (I - self.reward_integral_for[addr]) / 10 ** 18
+    self.reward_integral_for[addr] = I
+
+
+@external
+def user_checkpoint(addr: address) -> bool:
+    """
+    @notice Record a checkpoint for `addr`
+    @param addr User address
+    @return bool success
+    """
+    assert msg.sender == addr or msg.sender == self.minter  # dev: unauthorized
+    self._checkpoint(addr)
+    return True
+
+
+@external
+def claimable_tokens(addr: address) -> uint256:
+    """
+    @notice Get the number of claimable tokens per user
+    @dev This function should be manually changed to "view" in the ABI
+    @return uint256 number of claimable tokens per user
+    """
+    d_reward: uint256 = LiquidityGauge(self.gauge).claimable_tokens(self)
+
+    total_balance: uint256 = self.totalSupply
+    dI: uint256 = 0
+    if total_balance > 0:
+        dI = 10 ** 18 * d_reward / total_balance
+    I: uint256 = self.crv_integral + dI
+
+    return self.claimable_crv[addr] + self.balanceOf[addr] * (I - self.crv_integral_for[addr]) / 10 ** 18
+
+
+@view
+@external
+def claimable_reward(addr: address) -> uint256:
+    """
+    @notice Get the number of claimable tokens per user
+    @dev This function should be manually changed to "view" in the ABI
+    @return uint256 number of claimable tokens per user
+    """
+    gauge: address = self.gauge
+    d_reward: uint256 = LiquidityGauge(gauge).claimable_reward(self) - LiquidityGauge(gauge).claimed_rewards_for(self)
+
+    total_balance: uint256 = self.totalSupply
+    dI: uint256 = 0
+    if total_balance > 0:
+        dI = 10 ** 18 * d_reward / total_balance
+    I: uint256 = self.reward_integral + dI
+
+    return self.claimable_rewards[addr] + self.balanceOf[addr] * (I - self.reward_integral_for[addr]) / 10 ** 18
+
+
+
+@external
+@nonreentrant('lock')
+def claim_tokens(addr: address = msg.sender):
+    """
+    @notice Claim mintable CRV and reward tokens
+    @param addr Address to claim for
+    """
+    self._checkpoint(addr)
+    assert ERC20(self.crv_token).transfer(addr, self.claimable_crv[addr])
+    assert ERC20(self.rewarded_token).transfer(addr, self.claimable_rewards[addr])
+
+    self.claimable_crv[addr] = 0
+    self.claimable_rewards[addr] = 0
+
+
+@external
+def set_approve_deposit(addr: address, can_deposit: bool):
+    """
+    @notice Set whether `addr` can deposit tokens for `msg.sender`
+    @param addr Address to set approval on
+    @param can_deposit bool - can this account deposit for `msg.sender`?
+    """
+    self.approved_to_deposit[addr][msg.sender] = can_deposit
+
+
+@external
+@nonreentrant('lock')
+def deposit(_value: uint256, addr: address = msg.sender):
+    """
+    @notice Deposit `_value` LP tokens
+    @param _value Number of tokens to deposit
+    @param addr Address to deposit for
+    """
+    assert not self.is_killed
+
+    if addr != msg.sender:
+        assert self.approved_to_deposit[msg.sender][addr], "Not approved"
+
+    self._checkpoint(addr)
+
+    if _value != 0:
+        self.balanceOf[addr] += _value
+        self.totalSupply += _value
+
+        ERC20(self.lp_token).transferFrom(msg.sender, self, _value)
+        LiquidityGauge(self.gauge).deposit(_value)
+
+    log Deposit(addr, _value)
+
+
+@external
+@nonreentrant('lock')
+def withdraw(_value: uint256):
+    """
+    @notice Withdraw `_value` LP tokens
+    @param _value Number of tokens to withdraw
+    """
+    self._checkpoint(msg.sender)
+
+    if _value != 0:
+        self.balanceOf[msg.sender] -= _value
+        self.totalSupply -= _value
+
+        LiquidityGauge(self.gauge).withdraw(_value)
+        ERC20(self.lp_token).transfer(msg.sender, _value)
+
+    log Withdraw(msg.sender, _value)
+
+
+@view
+@external
+def allowance(_owner : address, _spender : address) -> uint256:
+    """
+    @dev Function to check the amount of tokens that an owner allowed to a spender.
+    @param _owner The address which owns the funds.
+    @param _spender The address which will spend the funds.
+    @return An uint256 specifying the amount of tokens still available for the spender.
+    """
+    return self.allowances[_owner][_spender]
+
+
+@internal
+def _transfer(_from: address, _to: address, _value: uint256):
+    assert not self.is_killed
+
+    self._checkpoint(_from)
+    self._checkpoint(_to)
+
+    if _value != 0:
+        self.balanceOf[_from] -= _value
+        self.balanceOf[_to] += _value
+
+    log Transfer(_from, _to, _value)
+
+
+@external
+@nonreentrant('lock')
+def transfer(_to : address, _value : uint256) -> bool:
+    """
+    @dev Transfer token for a specified address
+    @param _to The address to transfer to.
+    @param _value The amount to be transferred.
+    """
+    self._transfer(msg.sender, _to, _value)
+
+    return True
+
+
+@external
+@nonreentrant('lock')
+def transferFrom(_from : address, _to : address, _value : uint256) -> bool:
+    """
+     @dev Transfer tokens from one address to another.
+     @param _from address The address which you want to send tokens from
+     @param _to address The address which you want to transfer to
+     @param _value uint256 the amount of tokens to be transferred
+    """
+    _allowance: uint256 = self.allowances[_from][msg.sender]
+    if _allowance != MAX_UINT256:
+        self.allowances[_from][msg.sender] = _allowance - _value
+
+    self._transfer(_from, _to, _value)
+
+    return True
+
+
+@external
+def approve(_spender : address, _value : uint256) -> bool:
+    """
+    @notice Approve the passed address to transfer the specified amount of
+            tokens on behalf of msg.sender
+    @dev Beware that changing an allowance via this method brings the risk
+         that someone may use both the old and new allowance by unfortunate
+         transaction ordering. This may be mitigated with the use of
+         {increaseAllowance} and {decreaseAllowance}.
+         https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+    @param _spender The address which will transfer the funds
+    @param _value The amount of tokens that may be transferred
+    @return bool success
+    """
+    self.allowances[msg.sender][_spender] = _value
+    log Approval(msg.sender, _spender, _value)
+
+    return True
+
+
+@external
+def increaseAllowance(_spender: address, _added_value: uint256) -> bool:
+    """
+    @notice Increase the allowance granted to `_spender` by the caller
+    @dev This is alternative to {approve} that can be used as a mitigation for
+         the potential race condition
+    @param _spender The address which will transfer the funds
+    @param _added_value The amount of to increase the allowance
+    @return bool success
+    """
+    allowance: uint256 = self.allowances[msg.sender][_spender] + _added_value
+    self.allowances[msg.sender][_spender] = allowance
+
+    log Approval(msg.sender, _spender, allowance)
+
+    return True
+
+
+@external
+def decreaseAllowance(_spender: address, _subtracted_value: uint256) -> bool:
+    """
+    @notice Decrease the allowance granted to `_spender` by the caller
+    @dev This is alternative to {approve} that can be used as a mitigation for
+         the potential race condition
+    @param _spender The address which will transfer the funds
+    @param _subtracted_value The amount of to decrease the allowance
+    @return bool success
+    """
+    allowance: uint256 = self.allowances[msg.sender][_spender] - _subtracted_value
+    self.allowances[msg.sender][_spender] = allowance
+
+    log Approval(msg.sender, _spender, allowance)
+
+    return True
+
+
+@external
+def kill_me():
+    assert msg.sender == self.admin
+    self.is_killed = not self.is_killed
+
+
+@external
+def commit_transfer_ownership(addr: address):
+    """
+    @notice Transfer ownership of GaugeController to `addr`
+    @param addr Address to have ownership transferred to
+    """
+    assert msg.sender == self.admin  # dev: admin only
+    self.future_admin = addr
+    log CommitOwnership(addr)
+
+
+@external
+def apply_transfer_ownership():
+    """
+    @notice Apply pending ownership transfer
+    """
+    assert msg.sender == self.admin  # dev: admin only
+    _admin: address = self.future_admin
+    assert _admin != ZERO_ADDRESS  # dev: admin not set
+    self.admin = _admin
+    log ApplyOwnership(_admin)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,6 +95,11 @@ def liquidity_gauge_reward(LiquidityGaugeReward, accounts, mock_lp_token, minter
 
 
 @pytest.fixture(scope="module")
+def reward_gauge_wrapper(LiquidityGaugeRewardWrapper, accounts, liquidity_gauge_reward):
+    yield LiquidityGaugeRewardWrapper.deploy("Tokenized Reward Gauge", "TG", liquidity_gauge_reward, accounts[0], {'from': accounts[0]})
+
+
+@pytest.fixture(scope="module")
 def three_gauges(LiquidityGauge, accounts, mock_lp_token, minter):
     contracts = [
         LiquidityGauge.deploy(mock_lp_token, minter, accounts[0], {'from': accounts[0]})

--- a/tests/unitary/LiquidityGaugeRewardWrapper/test_approve.py
+++ b/tests/unitary/LiquidityGaugeRewardWrapper/test_approve.py
@@ -1,0 +1,69 @@
+#!/usr/bin/python3
+
+import brownie
+import pytest
+
+
+@pytest.mark.parametrize("idx", range(5))
+def test_initial_approval_is_zero(reward_gauge_wrapper, accounts, idx):
+    assert reward_gauge_wrapper.allowance(accounts[0], accounts[idx]) == 0
+
+
+def test_approve(reward_gauge_wrapper, accounts):
+    reward_gauge_wrapper.approve(accounts[1], 10**19, {'from': accounts[0]})
+
+    assert reward_gauge_wrapper.allowance(accounts[0], accounts[1]) == 10**19
+
+
+def test_modify_approve(reward_gauge_wrapper, accounts):
+    reward_gauge_wrapper.approve(accounts[1], 10**19, {'from': accounts[0]})
+    reward_gauge_wrapper.approve(accounts[1], 12345678, {'from': accounts[0]})
+
+    assert reward_gauge_wrapper.allowance(accounts[0], accounts[1]) == 12345678
+
+
+def test_revoke_approve(reward_gauge_wrapper, accounts):
+    reward_gauge_wrapper.approve(accounts[1], 10**19, {'from': accounts[0]})
+    reward_gauge_wrapper.approve(accounts[1], 0, {'from': accounts[0]})
+
+    assert reward_gauge_wrapper.allowance(accounts[0], accounts[1]) == 0
+
+
+def test_approve_self(reward_gauge_wrapper, accounts):
+    reward_gauge_wrapper.approve(accounts[0], 10**19, {'from': accounts[0]})
+
+    assert reward_gauge_wrapper.allowance(accounts[0], accounts[0]) == 10**19
+
+
+def test_only_affects_target(reward_gauge_wrapper, accounts):
+    reward_gauge_wrapper.approve(accounts[1], 10**19, {'from': accounts[0]})
+
+    assert reward_gauge_wrapper.allowance(accounts[1], accounts[0]) == 0
+
+
+def test_returns_true(reward_gauge_wrapper, accounts):
+    tx = reward_gauge_wrapper.approve(accounts[1], 10**19, {'from': accounts[0]})
+
+    assert tx.return_value is True
+
+
+def test_approval_event_fires(accounts, reward_gauge_wrapper):
+    tx = reward_gauge_wrapper.approve(accounts[1], 10**19, {'from': accounts[0]})
+
+    assert len(tx.events) == 1
+    assert tx.events["Approval"].values() == [accounts[0], accounts[1], 10**19]
+
+
+def test_increase_allowance(accounts, reward_gauge_wrapper):
+    reward_gauge_wrapper.approve(accounts[1], 100, {'from': accounts[0]})
+    reward_gauge_wrapper.increaseAllowance(accounts[1], 403, {'from': accounts[0]})
+
+    assert reward_gauge_wrapper.allowance(accounts[0], accounts[1]) == 503
+
+
+def test_decrease_allowance(accounts, reward_gauge_wrapper):
+    reward_gauge_wrapper.approve(accounts[1], 100, {'from': accounts[0]})
+    reward_gauge_wrapper.decreaseAllowance(accounts[1], 34, {'from': accounts[0]})
+
+    assert reward_gauge_wrapper.allowance(accounts[0], accounts[1]) == 66
+

--- a/tests/unitary/LiquidityGaugeRewardWrapper/test_checkpoint.py
+++ b/tests/unitary/LiquidityGaugeRewardWrapper/test_checkpoint.py
@@ -1,0 +1,26 @@
+import brownie
+import pytest
+
+YEAR = 86400 * 365
+
+@pytest.fixture(scope="module", autouse=True)
+def setup(accounts, gauge_controller, minter, liquidity_gauge_reward, token):
+    token.set_minter(minter, {'from': accounts[0]})
+
+    gauge_controller.add_type(b'Liquidity', 10**10, {'from': accounts[0]})
+    gauge_controller.add_gauge(liquidity_gauge_reward, 0, 0, {'from': accounts[0]})
+
+
+def test_user_checkpoint(accounts, reward_gauge_wrapper):
+    reward_gauge_wrapper.user_checkpoint(accounts[1], {'from': accounts[1]})
+
+
+def test_user_checkpoint_new_period(accounts, chain, reward_gauge_wrapper):
+    reward_gauge_wrapper.user_checkpoint(accounts[1], {'from': accounts[1]})
+    chain.sleep(int(YEAR * 1.1))
+    reward_gauge_wrapper.user_checkpoint(accounts[1], {'from': accounts[1]})
+
+
+def test_user_checkpoint_wrong_account(accounts, reward_gauge_wrapper):
+    with brownie.reverts("dev: unauthorized"):
+        reward_gauge_wrapper.user_checkpoint(accounts[2], {'from': accounts[1]})

--- a/tests/unitary/LiquidityGaugeRewardWrapper/test_claim_tokens.py
+++ b/tests/unitary/LiquidityGaugeRewardWrapper/test_claim_tokens.py
@@ -1,0 +1,147 @@
+import brownie
+import pytest
+import itertools
+
+MONTH = 86400 * 30
+WEEK = 86400 * 7
+
+@pytest.fixture(scope="module", autouse=True)
+def setup(accounts, mock_lp_token, token, minter, gauge_controller, liquidity_gauge_reward, reward_gauge_wrapper, reward_contract, coin_reward):
+    token.set_minter(minter, {'from': accounts[0]})
+
+    gauge_controller.add_type(b'Liquidity', 10**10, {'from': accounts[0]})
+    gauge_controller.add_gauge(liquidity_gauge_reward, 0, 10**18, {'from': accounts[0]})
+
+    coin_reward._mint_for_testing(10**20, {'from': accounts[0]})
+    coin_reward.transfer(reward_contract, 10**20, {'from': accounts[0]})
+    reward_contract.notifyRewardAmount(10**20, {'from': accounts[0]})
+
+    # transfer tokens
+    for acct in accounts[1:3]:
+        mock_lp_token.transfer(acct, 1e18, {'from': accounts[0]})
+
+    # approve gauge and wrapper
+    for gauge, acct in itertools.product([liquidity_gauge_reward, reward_gauge_wrapper], accounts[1:3]):
+        mock_lp_token.approve(gauge, 1e18, {'from': acct})
+
+
+def test_claim_crv(accounts, chain, liquidity_gauge_reward, reward_gauge_wrapper, token):
+    reward_gauge_wrapper.deposit(1e18, {'from': accounts[1]})
+
+    chain.sleep(MONTH)
+    reward_gauge_wrapper.claim_tokens({'from': accounts[1]})
+    expected = liquidity_gauge_reward.integrate_fraction(reward_gauge_wrapper)
+
+    assert expected > 0
+    assert token.balanceOf(accounts[1]) == expected
+
+
+def test_claim_reward(accounts, chain, liquidity_gauge_reward, reward_gauge_wrapper, coin_reward):
+    reward_gauge_wrapper.deposit(1e18, {'from': accounts[1]})
+
+    chain.sleep(MONTH)
+    reward_gauge_wrapper.claim_tokens({'from': accounts[1]})
+
+    assert coin_reward.balanceOf(accounts[1]) > 0
+    assert coin_reward.balanceOf(reward_gauge_wrapper) == 0
+
+
+def test_multiple_depositors(accounts, chain, liquidity_gauge_reward, reward_gauge_wrapper, token):
+    reward_gauge_wrapper.deposit(1e18, {'from': accounts[1]})
+
+    chain.sleep(MONTH)
+    reward_gauge_wrapper.deposit(1e18, {'from': accounts[2]})
+    chain.sleep(MONTH)
+    reward_gauge_wrapper.withdraw(1e18, {'from': accounts[1]})
+    reward_gauge_wrapper.withdraw(1e18, {'from': accounts[2]})
+    chain.sleep(10)
+
+
+    reward_gauge_wrapper.claim_tokens({'from': accounts[1]})
+    reward_gauge_wrapper.claim_tokens({'from': accounts[2]})
+
+    expected = liquidity_gauge_reward.integrate_fraction(reward_gauge_wrapper)
+    actual = token.balanceOf(accounts[1]) + token.balanceOf(accounts[2])
+
+    assert expected > 0
+    assert 0 <= expected - actual <= 1
+
+
+def test_claim_reward_multiple(accounts, chain, liquidity_gauge_reward, reward_gauge_wrapper, coin_reward):
+    reward_gauge_wrapper.deposit(1e18, {'from': accounts[1]})
+
+    chain.sleep(WEEK // 2)
+    reward_gauge_wrapper.deposit(10**18, {'from': accounts[2]})
+    chain.sleep(WEEK)
+
+    reward_gauge_wrapper.claim_tokens({'from': accounts[1]})
+    reward_gauge_wrapper.claim_tokens({'from': accounts[2]})
+
+    assert coin_reward.balanceOf(reward_gauge_wrapper) <= 1
+    assert 0.9999 < coin_reward.balanceOf(accounts[2]) * 3 / coin_reward.balanceOf(accounts[1]) <= 1
+
+
+def test_multiple_claims(accounts, chain, liquidity_gauge_reward, reward_gauge_wrapper, token):
+    reward_gauge_wrapper.deposit(1e18, {'from': accounts[1]})
+
+    chain.sleep(MONTH)
+    reward_gauge_wrapper.claim_tokens({'from': accounts[1]})
+    balance = token.balanceOf(accounts[1])
+
+    chain.sleep(MONTH)
+    reward_gauge_wrapper.claim_tokens({'from': accounts[1]})
+    expected = liquidity_gauge_reward.integrate_fraction(reward_gauge_wrapper)
+    final_balance = token.balanceOf(accounts[1])
+
+    assert final_balance > balance
+    assert final_balance == expected
+
+
+def test_multiple_claims_reward(accounts, chain, liquidity_gauge_reward, reward_gauge_wrapper, coin_reward):
+    reward_gauge_wrapper.deposit(1e18, {'from': accounts[1]})
+
+    chain.sleep(86400)
+    reward_gauge_wrapper.claim_tokens({'from': accounts[1]})
+    balance = coin_reward.balanceOf(accounts[1])
+
+    chain.sleep(86400)
+    reward_gauge_wrapper.claim_tokens({'from': accounts[1]})
+    expected = liquidity_gauge_reward.claimed_rewards_for(reward_gauge_wrapper)
+    final_balance = coin_reward.balanceOf(accounts[1])
+
+    assert final_balance > balance
+    assert final_balance == expected
+
+
+def test_claim_without_deposit(accounts, chain, reward_gauge_wrapper, token, coin_reward):
+    reward_gauge_wrapper.claim_tokens({'from': accounts[1]})
+
+    assert token.balanceOf(accounts[1]) == 0
+    assert coin_reward.balanceOf(accounts[1]) == 0
+
+
+def test_claimable_no_deposit(accounts, reward_gauge_wrapper):
+    assert reward_gauge_wrapper.claimable_tokens.call(accounts[1]) == 0
+    assert reward_gauge_wrapper.claimable_reward(accounts[1]) == 0
+
+
+def test_claimable_tokens(accounts, chain, reward_gauge_wrapper, token):
+    reward_gauge_wrapper.deposit(1e18, {'from': accounts[1]})
+
+    chain.sleep(MONTH)
+    chain.mine()
+    claimable = reward_gauge_wrapper.claimable_tokens.call(accounts[1])
+
+    reward_gauge_wrapper.claim_tokens({'from': accounts[1]})
+    assert token.balanceOf(accounts[1]) >= claimable > 0
+
+
+def test_claimable_reward(accounts, chain, reward_gauge_wrapper, coin_reward):
+    reward_gauge_wrapper.deposit(1e18, {'from': accounts[1]})
+
+    chain.sleep(MONTH)
+    chain.mine()
+    claimable = reward_gauge_wrapper.claimable_reward(accounts[1])
+
+    reward_gauge_wrapper.claim_tokens({'from': accounts[1]})
+    assert coin_reward.balanceOf(accounts[1]) == claimable

--- a/tests/unitary/LiquidityGaugeRewardWrapper/test_deposit_withdraw.py
+++ b/tests/unitary/LiquidityGaugeRewardWrapper/test_deposit_withdraw.py
@@ -1,0 +1,116 @@
+import brownie
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup(accounts, gauge_controller, minter, liquidity_gauge_reward, reward_gauge_wrapper, token, mock_lp_token):
+    token.set_minter(minter, {'from': accounts[0]})
+
+    gauge_controller.add_type(b'Liquidity', 10**10, {'from': accounts[0]})
+    gauge_controller.add_gauge(liquidity_gauge_reward, 0, 0, {'from': accounts[0]})
+
+    mock_lp_token.approve(reward_gauge_wrapper, 2 ** 256 - 1, {"from": accounts[0]})
+
+
+def test_deposit(accounts, liquidity_gauge_reward, reward_gauge_wrapper, reward_contract, mock_lp_token):
+    balance = mock_lp_token.balanceOf(accounts[0])
+    reward_gauge_wrapper.deposit(100000, {'from': accounts[0]})
+
+    assert mock_lp_token.balanceOf(reward_contract) == 100000
+    assert mock_lp_token.balanceOf(reward_gauge_wrapper) == 0
+    assert mock_lp_token.balanceOf(accounts[0]) == balance - 100000
+
+    assert liquidity_gauge_reward.totalSupply() == 100000
+    assert liquidity_gauge_reward.balanceOf(reward_gauge_wrapper) == 100000
+
+    assert reward_gauge_wrapper.totalSupply() == 100000
+    assert reward_gauge_wrapper.balanceOf(accounts[0]) == 100000
+
+
+def test_deposit_zero(accounts, liquidity_gauge_reward, reward_gauge_wrapper, reward_contract, mock_lp_token):
+    balance = mock_lp_token.balanceOf(accounts[0])
+    liquidity_gauge_reward.deposit(0, {'from': accounts[0]})
+
+    assert mock_lp_token.balanceOf(reward_contract) == 0
+    assert mock_lp_token.balanceOf(reward_gauge_wrapper) == 0
+    assert mock_lp_token.balanceOf(accounts[0]) == balance
+
+    assert liquidity_gauge_reward.totalSupply() == 0
+    assert liquidity_gauge_reward.balanceOf(reward_gauge_wrapper) == 0
+
+    assert reward_gauge_wrapper.totalSupply() == 0
+    assert reward_gauge_wrapper.balanceOf(accounts[0]) == 0
+
+
+def test_deposit_insufficient_balance(accounts, reward_gauge_wrapper):
+    with brownie.reverts():
+        reward_gauge_wrapper.deposit(100000, {'from': accounts[1]})
+
+
+def test_withdraw(accounts, liquidity_gauge_reward, reward_gauge_wrapper, reward_contract, mock_lp_token):
+    balance = mock_lp_token.balanceOf(accounts[0])
+
+    reward_gauge_wrapper.deposit(100000, {'from': accounts[0]})
+    reward_gauge_wrapper.withdraw(100000, {'from': accounts[0]})
+
+    assert mock_lp_token.balanceOf(reward_contract) == 0
+    assert mock_lp_token.balanceOf(reward_gauge_wrapper) == 0
+    assert mock_lp_token.balanceOf(accounts[0]) == balance
+
+    assert liquidity_gauge_reward.totalSupply() == 0
+    assert liquidity_gauge_reward.balanceOf(reward_gauge_wrapper) == 0
+
+    assert reward_gauge_wrapper.totalSupply() == 0
+    assert reward_gauge_wrapper.balanceOf(accounts[0]) == 0
+
+
+def test_withdraw_zero(accounts, liquidity_gauge_reward, reward_gauge_wrapper, reward_contract, mock_lp_token):
+    balance = mock_lp_token.balanceOf(accounts[0])
+    reward_gauge_wrapper.deposit(100000, {'from': accounts[0]})
+    reward_gauge_wrapper.withdraw(0, {'from': accounts[0]})
+
+    assert mock_lp_token.balanceOf(reward_contract) == 100000
+    assert mock_lp_token.balanceOf(reward_gauge_wrapper) == 0
+    assert mock_lp_token.balanceOf(accounts[0]) == balance - 100000
+
+    assert liquidity_gauge_reward.totalSupply() == 100000
+    assert liquidity_gauge_reward.balanceOf(reward_gauge_wrapper) == 100000
+
+    assert reward_gauge_wrapper.totalSupply() == 100000
+    assert reward_gauge_wrapper.balanceOf(accounts[0]) == 100000
+
+
+def test_withdraw_new_epoch(accounts, chain, liquidity_gauge_reward, reward_gauge_wrapper, reward_contract, mock_lp_token):
+    balance = mock_lp_token.balanceOf(accounts[0])
+
+    reward_gauge_wrapper.deposit(100000, {'from': accounts[0]})
+    chain.sleep(86400 * 400)
+    reward_gauge_wrapper.withdraw(100000, {'from': accounts[0]})
+
+    assert mock_lp_token.balanceOf(reward_contract) == 0
+    assert mock_lp_token.balanceOf(reward_gauge_wrapper) == 0
+    assert mock_lp_token.balanceOf(accounts[0]) == balance
+
+    assert liquidity_gauge_reward.totalSupply() == 0
+    assert liquidity_gauge_reward.balanceOf(reward_gauge_wrapper) == 0
+
+    assert reward_gauge_wrapper.totalSupply() == 0
+    assert reward_gauge_wrapper.balanceOf(accounts[0]) == 0
+
+
+def test_transfer_and_withdraw(accounts, reward_gauge_wrapper, mock_lp_token):
+
+    reward_gauge_wrapper.deposit(100000, {'from': accounts[0]})
+    reward_gauge_wrapper.transfer(accounts[1], 100000)
+    reward_gauge_wrapper.withdraw(100000, {'from': accounts[1]})
+
+    assert mock_lp_token.balanceOf(accounts[1]) == 100000
+
+
+def test_cannot_withdraw_after_transfer(accounts, reward_gauge_wrapper, mock_lp_token):
+
+    reward_gauge_wrapper.deposit(100000, {'from': accounts[0]})
+    reward_gauge_wrapper.transfer(accounts[1], 100000)
+
+    with brownie.reverts():
+        reward_gauge_wrapper.withdraw(100000, {'from': accounts[0]})

--- a/tests/unitary/LiquidityGaugeRewardWrapper/test_transfer.py
+++ b/tests/unitary/LiquidityGaugeRewardWrapper/test_transfer.py
@@ -1,0 +1,91 @@
+#!/usr/bin/python3
+import brownie
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup(accounts, gauge_controller, minter, liquidity_gauge_reward, reward_gauge_wrapper, token, mock_lp_token):
+    token.set_minter(minter, {'from': accounts[0]})
+
+    gauge_controller.add_type(b'Liquidity', 10**10, {'from': accounts[0]})
+    gauge_controller.add_gauge(liquidity_gauge_reward, 0, 0, {'from': accounts[0]})
+
+    mock_lp_token.approve(reward_gauge_wrapper, 2 ** 256 - 1, {"from": accounts[0]})
+    reward_gauge_wrapper.deposit(10**18, {'from': accounts[0]})
+
+
+def test_sender_balance_decreases(accounts, reward_gauge_wrapper):
+    sender_balance = reward_gauge_wrapper.balanceOf(accounts[0])
+    amount = sender_balance // 4
+
+    reward_gauge_wrapper.transfer(accounts[1], amount, {'from': accounts[0]})
+
+    assert reward_gauge_wrapper.balanceOf(accounts[0]) == sender_balance - amount
+
+
+def test_receiver_balance_increases(accounts, reward_gauge_wrapper):
+    receiver_balance = reward_gauge_wrapper.balanceOf(accounts[1])
+    amount = reward_gauge_wrapper.balanceOf(accounts[0]) // 4
+
+    reward_gauge_wrapper.transfer(accounts[1], amount, {'from': accounts[0]})
+
+    assert reward_gauge_wrapper.balanceOf(accounts[1]) == receiver_balance + amount
+
+
+def test_total_supply_not_affected(accounts, reward_gauge_wrapper):
+    total_supply = reward_gauge_wrapper.totalSupply()
+    amount = reward_gauge_wrapper.balanceOf(accounts[0])
+
+    reward_gauge_wrapper.transfer(accounts[1], amount, {'from': accounts[0]})
+
+    assert reward_gauge_wrapper.totalSupply() == total_supply
+
+
+def test_returns_true(accounts, reward_gauge_wrapper):
+    amount = reward_gauge_wrapper.balanceOf(accounts[0])
+    tx = reward_gauge_wrapper.transfer(accounts[1], amount, {'from': accounts[0]})
+
+    assert tx.return_value is True
+
+
+def test_transfer_full_balance(accounts, reward_gauge_wrapper):
+    amount = reward_gauge_wrapper.balanceOf(accounts[0])
+    receiver_balance = reward_gauge_wrapper.balanceOf(accounts[1])
+
+    reward_gauge_wrapper.transfer(accounts[1], amount, {'from': accounts[0]})
+
+    assert reward_gauge_wrapper.balanceOf(accounts[0]) == 0
+    assert reward_gauge_wrapper.balanceOf(accounts[1]) == receiver_balance + amount
+
+
+def test_transfer_zero_tokens(accounts, reward_gauge_wrapper):
+    sender_balance = reward_gauge_wrapper.balanceOf(accounts[0])
+    receiver_balance = reward_gauge_wrapper.balanceOf(accounts[1])
+
+    reward_gauge_wrapper.transfer(accounts[1], 0, {'from': accounts[0]})
+
+    assert reward_gauge_wrapper.balanceOf(accounts[0]) == sender_balance
+    assert reward_gauge_wrapper.balanceOf(accounts[1]) == receiver_balance
+
+
+def test_transfer_to_self(accounts, reward_gauge_wrapper):
+    sender_balance = reward_gauge_wrapper.balanceOf(accounts[0])
+    amount = sender_balance // 4
+
+    reward_gauge_wrapper.transfer(accounts[0], amount, {'from': accounts[0]})
+
+    assert reward_gauge_wrapper.balanceOf(accounts[0]) == sender_balance
+
+
+def test_insufficient_balance(accounts, reward_gauge_wrapper):
+    balance = reward_gauge_wrapper.balanceOf(accounts[0])
+
+    with brownie.reverts():
+        reward_gauge_wrapper.transfer(accounts[1], balance + 1, {'from': accounts[0]})
+
+
+def test_transfer_event_fires(accounts, reward_gauge_wrapper):
+    amount = reward_gauge_wrapper.balanceOf(accounts[0])
+    tx = reward_gauge_wrapper.transfer(accounts[1], amount, {'from': accounts[0]})
+
+    assert tx.events["Transfer"][-1].values() == [accounts[0], accounts[1], amount]

--- a/tests/unitary/LiquidityGaugeRewardWrapper/test_transferFrom.py
+++ b/tests/unitary/LiquidityGaugeRewardWrapper/test_transferFrom.py
@@ -1,0 +1,182 @@
+#!/usr/bin/python3
+import brownie
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup(accounts, gauge_controller, minter, liquidity_gauge_reward, reward_gauge_wrapper, token, mock_lp_token):
+    token.set_minter(minter, {'from': accounts[0]})
+
+    gauge_controller.add_type(b'Liquidity', 10**10, {'from': accounts[0]})
+    gauge_controller.add_gauge(liquidity_gauge_reward, 0, 0, {'from': accounts[0]})
+
+    mock_lp_token.approve(reward_gauge_wrapper, 2 ** 256 - 1, {"from": accounts[0]})
+    reward_gauge_wrapper.deposit(10**18, {'from': accounts[0]})
+
+
+def test_sender_balance_decreases(accounts, reward_gauge_wrapper):
+    sender_balance = reward_gauge_wrapper.balanceOf(accounts[0])
+    amount = sender_balance // 4
+
+    reward_gauge_wrapper.approve(accounts[1], amount, {'from': accounts[0]})
+    reward_gauge_wrapper.transferFrom(accounts[0], accounts[2], amount, {'from': accounts[1]})
+
+    assert reward_gauge_wrapper.balanceOf(accounts[0]) == sender_balance - amount
+
+
+def test_receiver_balance_increases(accounts, reward_gauge_wrapper):
+    receiver_balance = reward_gauge_wrapper.balanceOf(accounts[2])
+    amount = reward_gauge_wrapper.balanceOf(accounts[0]) // 4
+
+    reward_gauge_wrapper.approve(accounts[1], amount, {'from': accounts[0]})
+    reward_gauge_wrapper.transferFrom(accounts[0], accounts[2], amount, {'from': accounts[1]})
+
+    assert reward_gauge_wrapper.balanceOf(accounts[2]) == receiver_balance + amount
+
+
+def test_caller_balance_not_affected(accounts, reward_gauge_wrapper):
+    caller_balance = reward_gauge_wrapper.balanceOf(accounts[1])
+    amount = reward_gauge_wrapper.balanceOf(accounts[0])
+
+    reward_gauge_wrapper.approve(accounts[1], amount, {'from': accounts[0]})
+    reward_gauge_wrapper.transferFrom(accounts[0], accounts[2], amount, {'from': accounts[1]})
+
+    assert reward_gauge_wrapper.balanceOf(accounts[1]) == caller_balance
+
+
+def test_caller_approval_affected(accounts, reward_gauge_wrapper):
+    approval_amount = reward_gauge_wrapper.balanceOf(accounts[0])
+    transfer_amount = approval_amount // 4
+
+    reward_gauge_wrapper.approve(accounts[1], approval_amount, {'from': accounts[0]})
+    reward_gauge_wrapper.transferFrom(accounts[0], accounts[2], transfer_amount, {'from': accounts[1]})
+
+    assert reward_gauge_wrapper.allowance(accounts[0], accounts[1]) == approval_amount - transfer_amount
+
+
+def test_receiver_approval_not_affected(accounts, reward_gauge_wrapper):
+    approval_amount = reward_gauge_wrapper.balanceOf(accounts[0])
+    transfer_amount = approval_amount // 4
+
+    reward_gauge_wrapper.approve(accounts[1], approval_amount, {'from': accounts[0]})
+    reward_gauge_wrapper.approve(accounts[2], approval_amount, {'from': accounts[0]})
+    reward_gauge_wrapper.transferFrom(accounts[0], accounts[2], transfer_amount, {'from': accounts[1]})
+
+    assert reward_gauge_wrapper.allowance(accounts[0], accounts[2]) == approval_amount
+
+
+def test_total_supply_not_affected(accounts, reward_gauge_wrapper):
+    total_supply = reward_gauge_wrapper.totalSupply()
+    amount = reward_gauge_wrapper.balanceOf(accounts[0])
+
+    reward_gauge_wrapper.approve(accounts[1], amount, {'from': accounts[0]})
+    reward_gauge_wrapper.transferFrom(accounts[0], accounts[2], amount, {'from': accounts[1]})
+
+    assert reward_gauge_wrapper.totalSupply() == total_supply
+
+
+def test_returns_true(accounts, reward_gauge_wrapper):
+    amount = reward_gauge_wrapper.balanceOf(accounts[0])
+    reward_gauge_wrapper.approve(accounts[1], amount, {'from': accounts[0]})
+    tx = reward_gauge_wrapper.transferFrom(accounts[0], accounts[2], amount, {'from': accounts[1]})
+
+    assert tx.return_value is True
+
+
+def test_transfer_full_balance(accounts, reward_gauge_wrapper):
+    amount = reward_gauge_wrapper.balanceOf(accounts[0])
+    receiver_balance = reward_gauge_wrapper.balanceOf(accounts[2])
+
+    reward_gauge_wrapper.approve(accounts[1], amount, {'from': accounts[0]})
+    reward_gauge_wrapper.transferFrom(accounts[0], accounts[2], amount, {'from': accounts[1]})
+
+    assert reward_gauge_wrapper.balanceOf(accounts[0]) == 0
+    assert reward_gauge_wrapper.balanceOf(accounts[2]) == receiver_balance + amount
+
+
+def test_transfer_zero_tokens(accounts, reward_gauge_wrapper):
+    sender_balance = reward_gauge_wrapper.balanceOf(accounts[0])
+    receiver_balance = reward_gauge_wrapper.balanceOf(accounts[2])
+
+    reward_gauge_wrapper.approve(accounts[1], sender_balance, {'from': accounts[0]})
+    reward_gauge_wrapper.transferFrom(accounts[0], accounts[2], 0, {'from': accounts[1]})
+
+    assert reward_gauge_wrapper.balanceOf(accounts[0]) == sender_balance
+    assert reward_gauge_wrapper.balanceOf(accounts[2]) == receiver_balance
+
+
+def test_transfer_zero_tokens_without_approval(accounts, reward_gauge_wrapper):
+    sender_balance = reward_gauge_wrapper.balanceOf(accounts[0])
+    receiver_balance = reward_gauge_wrapper.balanceOf(accounts[2])
+
+    reward_gauge_wrapper.transferFrom(accounts[0], accounts[2], 0, {'from': accounts[1]})
+
+    assert reward_gauge_wrapper.balanceOf(accounts[0]) == sender_balance
+    assert reward_gauge_wrapper.balanceOf(accounts[2]) == receiver_balance
+
+
+def test_insufficient_balance(accounts, reward_gauge_wrapper):
+    balance = reward_gauge_wrapper.balanceOf(accounts[0])
+
+    reward_gauge_wrapper.approve(accounts[1], balance + 1, {'from': accounts[0]})
+    with brownie.reverts():
+        reward_gauge_wrapper.transferFrom(accounts[0], accounts[2], balance + 1, {'from': accounts[1]})
+
+
+def test_insufficient_approval(accounts, reward_gauge_wrapper):
+    balance = reward_gauge_wrapper.balanceOf(accounts[0])
+
+    reward_gauge_wrapper.approve(accounts[1], balance - 1, {'from': accounts[0]})
+    with brownie.reverts():
+        reward_gauge_wrapper.transferFrom(accounts[0], accounts[2], balance, {'from': accounts[1]})
+
+
+def test_no_approval(accounts, reward_gauge_wrapper):
+    balance = reward_gauge_wrapper.balanceOf(accounts[0])
+
+    with brownie.reverts():
+        reward_gauge_wrapper.transferFrom(accounts[0], accounts[2], balance, {'from': accounts[1]})
+
+
+def test_infinite_approval(accounts, reward_gauge_wrapper):
+    reward_gauge_wrapper.approve(accounts[1], 2**256-1, {'from': accounts[0]})
+    reward_gauge_wrapper.transferFrom(accounts[0], accounts[2], 10000, {'from': accounts[1]})
+
+    assert reward_gauge_wrapper.allowance(accounts[0], accounts[1]) == 2**256-1
+
+
+def test_revoked_approval(accounts, reward_gauge_wrapper):
+    balance = reward_gauge_wrapper.balanceOf(accounts[0])
+
+    reward_gauge_wrapper.approve(accounts[1], balance, {'from': accounts[0]})
+    reward_gauge_wrapper.approve(accounts[1], 0, {'from': accounts[0]})
+
+    with brownie.reverts():
+        reward_gauge_wrapper.transferFrom(accounts[0], accounts[2], balance, {'from': accounts[1]})
+
+
+def test_transfer_to_self(accounts, reward_gauge_wrapper):
+    sender_balance = reward_gauge_wrapper.balanceOf(accounts[0])
+    amount = sender_balance // 4
+
+    reward_gauge_wrapper.approve(accounts[0], sender_balance, {'from': accounts[0]})
+    reward_gauge_wrapper.transferFrom(accounts[0], accounts[0], amount, {'from': accounts[0]})
+
+    assert reward_gauge_wrapper.balanceOf(accounts[0]) == sender_balance
+    assert reward_gauge_wrapper.allowance(accounts[0], accounts[0]) == sender_balance - amount
+
+
+def test_transfer_to_self_no_approval(accounts, reward_gauge_wrapper):
+    amount = reward_gauge_wrapper.balanceOf(accounts[0])
+
+    with brownie.reverts():
+        reward_gauge_wrapper.transferFrom(accounts[0], accounts[0], amount, {'from': accounts[0]})
+
+
+def test_transfer_event_fires(accounts, reward_gauge_wrapper):
+    amount = reward_gauge_wrapper.balanceOf(accounts[0])
+
+    reward_gauge_wrapper.approve(accounts[1], amount, {'from': accounts[0]})
+    tx = reward_gauge_wrapper.transferFrom(accounts[0], accounts[2], amount, {'from': accounts[1]})
+
+    assert tx.events["Transfer"][-1].values() == [accounts[0], accounts[2], amount]


### PR DESCRIPTION
### What I did
Add a wrapper for `LiquidityGaugeRewards` that tokenizes deposits.

### How I did it
The logic is mostly taken from `LiquidityGaugeReward`.  Both CRV and the reward token are handled as reward tokens within the wrapper.  The contract interface is almost identical to existing gauges + ERC20, with one new method `claim_tokens` that claims both CRV and the reward token.

As with #53, when using this wrapper it is not possible to boost a deposit.

### How to verify
Run the tests.  I've added some new test modules specific to this contract.