### PR TITLE
Updates to `PoolProxy`

### DIFF
--- a/contracts/PoolProxy.vy
+++ b/contracts/PoolProxy.vy
@@ -86,6 +86,13 @@ def __init__(
     self.emergency_admin = _emergency_admin
 
 
+@payable
+@external
+def __default__():
+    # required to receive ETH fees
+    pass
+
+
 @external
 def commit_set_admins(_o_admin: address, _p_admin: address, _e_admin: address):
     """
@@ -131,7 +138,7 @@ def set_burner(_token: address, _burner: address):
     assert msg.sender == self.ownership_admin, "Access denied"
 
     old_burner: address = self.burners[_token]
-    if _token != ZERO_ADDRESS:
+    if _token != 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE:
         if old_burner != ZERO_ADDRESS:
             # revoke approval on previous burner
             response: Bytes[32] = raw_call(
@@ -196,13 +203,12 @@ def burn_coin(_coin: address):
 
 
 @external
-@payable
 @nonreentrant('lock')
 def burn_eth():
     """
     @notice Burn the full ETH balance of this contract
     """
-    Burner(self.burners[ZERO_ADDRESS]).burn_eth(value=self.balance)  # dev: should implement burn_eth()
+    Burner(self.burners[0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE]).burn_eth(value=self.balance)  # dev: should implement burn_eth()
 
 
 @external

--- a/contracts/PoolProxy.vy
+++ b/contracts/PoolProxy.vy
@@ -184,10 +184,23 @@ def withdraw_admin_fees(_pool: address):
 
 @external
 @nonreentrant('lock')
+def withdraw_many(_pools: address[20]):
+    """
+    @notice Withdraw admin fees from multiple pools
+    @param _pools List of pool address to withdraw admin fees from
+    """
+    for pool in _pools:
+        if pool == ZERO_ADDRESS:
+            break
+        Curve(pool).withdraw_admin_fees()
+
+
+@external
+@nonreentrant('lock')
 def burn(_burner: address):
     """
-    @notice Burn CRV tokens using `_burner` contract
-    @param _burner Burner contract
+    @notice Burn accrued admin fees using `_burner`
+    @param _burner Burner contract address
     """
     Burner(_burner).burn()  # dev: should implement burn()
 
@@ -196,7 +209,7 @@ def burn(_burner: address):
 @nonreentrant('lock')
 def burn_coin(_coin: address):
     """
-    @notice Burn CRV tokens and buy `_coin`
+    @notice Burn accrued `_coin` via a preset burner
     @param _coin Coin address
     """
     Burner(self.burners[_coin]).burn_coin(_coin)  # dev: should implement burn_coin()
@@ -209,6 +222,22 @@ def burn_eth():
     @notice Burn the full ETH balance of this contract
     """
     Burner(self.burners[0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE]).burn_eth(value=self.balance)  # dev: should implement burn_eth()
+
+
+@external
+@nonreentrant('lock')
+def burn_many(_coins: address[20]):
+    """
+    @notice Burn accrued admin fees from multiple coins
+    @param _coins List of coin addresses
+    """
+    for coin in _coins:
+        if coin == ZERO_ADDRESS:
+            break
+        if coin == 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE:
+            Burner(self.burners[0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE]).burn_eth(value=self.balance)
+        else:
+            Burner(self.burners[coin]).burn_coin(coin)
 
 
 @external

--- a/contracts/PoolProxy.vy
+++ b/contracts/PoolProxy.vy
@@ -126,20 +126,20 @@ def apply_set_admins():
 
 @external
 @nonreentrant('lock')
-def set_burner(_token: address, _burner: address):
+def set_burner(_coin: address, _burner: address):
     """
-    @notice Set burner of `_token` to `_burner` address
-    @param _token Token address
+    @notice Set burner of `_coin` to `_burner` address
+    @param _coin Token address
     @param _burner Burner contract address
     """
     assert msg.sender == self.ownership_admin, "Access denied"
 
-    old_burner: address = self.burners[_token]
-    if _token != 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE:
+    old_burner: address = self.burners[_coin]
+    if _coin != 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE:
         if old_burner != ZERO_ADDRESS:
             # revoke approval on previous burner
             response: Bytes[32] = raw_call(
-                _token,
+                _coin,
                 concat(
                     method_id("approve(address,uint256)"),
                     convert(old_burner, bytes32),
@@ -153,7 +153,7 @@ def set_burner(_token: address, _burner: address):
         if _burner != ZERO_ADDRESS:
             # infinite approval for current burner
             response: Bytes[32] = raw_call(
-                _token,
+                _coin,
                 concat(
                     method_id("approve(address,uint256)"),
                     convert(_burner, bytes32),
@@ -164,7 +164,7 @@ def set_burner(_token: address, _burner: address):
             if len(response) != 0:
                 assert convert(response, bool)
 
-    self.burners[_token] = _burner
+    self.burners[_coin] = _burner
 
     log AddBurner(_burner)
 

--- a/tests/unitary/PoolProxy/test_proxy_burn.py
+++ b/tests/unitary/PoolProxy/test_proxy_burn.py
@@ -1,26 +1,18 @@
 import brownie
 import pytest
 
+ETH_ADDRESS = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
 ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 
 burner_mock = """
+# @version 0.2.7
 
-is_burned: public(bool)
-burned_coin: public(address)
+is_burned: public(HashMap[address, bool])
 
-@external
-def burn() -> bool:
-    self.is_burned = True
-    return True
-
-@external
 @payable
-def burn_eth() -> bool:
-    return True
-
 @external
-def burn_coin(_coin: address) -> bool:
-    self.burned_coin = _coin
+def burn(coin: address) -> bool:
+    self.is_burned[coin] = True
     return True
 """
 
@@ -29,44 +21,49 @@ def burn_coin(_coin: address) -> bool:
 def burner(accounts, pool_proxy, coin_a):
     contract = brownie.compile_source(burner_mock).Vyper.deploy({'from': accounts[0]})
     pool_proxy.set_burner(coin_a, contract, {'from': accounts[0]})
-    pool_proxy.set_burner(ZERO_ADDRESS, contract, {'from': accounts[0]})
+    pool_proxy.set_burner(ETH_ADDRESS, contract, {'from': accounts[0]})
+    accounts[0].transfer(pool_proxy, 31337)
 
     yield contract
 
 
-@pytest.mark.parametrize('idx', range(4))
-def test_burn(accounts, pool_proxy, burner, idx):
-    pool_proxy.burn(burner, {'from': accounts[idx]})
+@pytest.mark.parametrize('idx', range(2))
+def test_burn(accounts, pool_proxy, burner, coin_a, idx):
+    pool_proxy.burn(coin_a, {'from': accounts[idx]})
 
-    assert burner.is_burned() is True
-
-
-@pytest.mark.parametrize('idx', range(4))
-def test_burn_coin(accounts, pool_proxy, coin_a, burner, idx):
-    pool_proxy.burn_coin(coin_a, {'from': accounts[idx]})
-
-    assert burner.burned_coin() == coin_a
+    assert burner.is_burned(coin_a)
+    assert pool_proxy.balance() == 31337
+    assert burner.balance() == 0
 
 
-@pytest.mark.parametrize('idx', range(4))
+@pytest.mark.parametrize('idx', range(2))
 def test_burn_eth(accounts, pool_proxy, burner, idx):
-    pool_proxy.burn_eth({'from': accounts[idx], 'value': 31337})
+    pool_proxy.burn(ETH_ADDRESS, {'from': accounts[idx]})
+
+    assert burner.is_burned(ETH_ADDRESS)
+    assert pool_proxy.balance() == 0
+    assert burner.balance() == 31337
+
+
+@pytest.mark.parametrize('idx', range(2))
+def test_burn_many(accounts, pool_proxy, burner, coin_a, idx):
+    pool_proxy.burn_many([coin_a, ETH_ADDRESS] + [ZERO_ADDRESS] * 8, {'from': accounts[0]})
+
+    assert burner.is_burned(coin_a)
+    assert burner.is_burned(ETH_ADDRESS)
 
     assert pool_proxy.balance() == 0
     assert burner.balance() == 31337
 
 
-def test_burn_not_exists(accounts, pool_proxy, pool):
+def test_burn_not_exists(accounts, pool_proxy):
     with brownie.reverts('dev: should implement burn()'):
-        pool_proxy.burn(pool, {'from': accounts[0]})
+        pool_proxy.burn(accounts[1], {'from': accounts[0]})
 
 
-def test_burn_coin_not_exists(accounts, pool_proxy, coin_b):
-    with brownie.reverts('dev: should implement burn_coin()'):
-        pool_proxy.burn_coin(coin_b, {'from': accounts[0]})
-
-
-def test_burn_eth_not_exists(accounts, pool_proxy, burner):
-    pool_proxy.set_burner(ZERO_ADDRESS, ZERO_ADDRESS, {'from': accounts[0]})
-    with brownie.reverts('dev: should implement burn_eth()'):
-        pool_proxy.burn_eth({'from': accounts[0], 'value': 1})
+def test_burn_many_not_exists(accounts, pool_proxy, burner, coin_a):
+    with brownie.reverts('dev: should implement burn()'):
+        pool_proxy.burn_many(
+            [coin_a, ETH_ADDRESS, accounts[1]] + [ZERO_ADDRESS] * 7,
+            {'from': accounts[0]}
+        )

--- a/tests/unitary/PoolProxy/test_proxy_burn.py
+++ b/tests/unitary/PoolProxy/test_proxy_burn.py
@@ -47,7 +47,7 @@ def test_burn_eth(accounts, pool_proxy, burner, idx):
 
 @pytest.mark.parametrize('idx', range(2))
 def test_burn_many(accounts, pool_proxy, burner, coin_a, idx):
-    pool_proxy.burn_many([coin_a, ETH_ADDRESS] + [ZERO_ADDRESS] * 8, {'from': accounts[0]})
+    pool_proxy.burn_many([coin_a, ETH_ADDRESS] + [ZERO_ADDRESS] * 18, {'from': accounts[0]})
 
     assert burner.is_burned(coin_a)
     assert burner.is_burned(ETH_ADDRESS)
@@ -64,6 +64,6 @@ def test_burn_not_exists(accounts, pool_proxy):
 def test_burn_many_not_exists(accounts, pool_proxy, burner, coin_a):
     with brownie.reverts('dev: should implement burn()'):
         pool_proxy.burn_many(
-            [coin_a, ETH_ADDRESS, accounts[1]] + [ZERO_ADDRESS] * 7,
+            [coin_a, ETH_ADDRESS, accounts[1]] + [ZERO_ADDRESS] * 17,
             {'from': accounts[0]}
         )


### PR DESCRIPTION
### What I did
* consolidate `PoolProxy` burner logic into a single function
* add `burn_many` and `withdraw_many` for aggregated admin fee claims / burning
* represent ether as `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE` instead of using `0x00`
* add a payable `__default__` method to allow receiving ether as a fee

### How to verify
Run the tests.  I've updated / expanded test cases around burning and withdrawing.