### PR TITLE
Add `Transfer` event for gauge deposits and withdrawals

### DIFF
--- a/contracts/gauges/LiquidityGaugeRewardWrapper.vy
+++ b/contracts/gauges/LiquidityGaugeRewardWrapper.vy
@@ -1,4 +1,4 @@
-# @version 0.2.7
+# @version 0.2.8
 """
 @title Tokenized Liquidity Gauge Wrapper
 @author Curve Finance

--- a/contracts/gauges/LiquidityGaugeRewardWrapper.vy
+++ b/contracts/gauges/LiquidityGaugeRewardWrapper.vy
@@ -243,6 +243,7 @@ def deposit(_value: uint256, addr: address = msg.sender):
         LiquidityGauge(self.gauge).deposit(_value)
 
     log Deposit(addr, _value)
+    log Transfer(ZERO_ADDRESS, addr, _value)
 
 
 @external
@@ -262,6 +263,7 @@ def withdraw(_value: uint256):
         ERC20(self.lp_token).transfer(msg.sender, _value)
 
     log Withdraw(msg.sender, _value)
+    log Transfer(msg.sender, ZERO_ADDRESS, _value)
 
 
 @view

--- a/contracts/gauges/LiquidityGaugeV2.vy
+++ b/contracts/gauges/LiquidityGaugeV2.vy
@@ -1,4 +1,4 @@
-# @version 0.2.7
+# @version 0.2.8
 """
 @title Liquidity Gauge v2
 @author Curve Finance

--- a/contracts/gauges/LiquidityGaugeV2.vy
+++ b/contracts/gauges/LiquidityGaugeV2.vy
@@ -464,6 +464,7 @@ def deposit(_value: uint256, _addr: address = msg.sender):
                 )
 
     log Deposit(_addr, _value)
+    log Transfer(ZERO_ADDRESS, _addr, _value)
 
 
 @external
@@ -499,6 +500,7 @@ def withdraw(_value: uint256):
         ERC20(self.lp_token).transfer(msg.sender, _value)
 
     log Withdraw(msg.sender, _value)
+    log Transfer(msg.sender, ZERO_ADDRESS, _value)
 
 
 @view

--- a/contracts/gauges/LiquidityGaugeWrapper.vy
+++ b/contracts/gauges/LiquidityGaugeWrapper.vy
@@ -1,4 +1,4 @@
-# @version 0.2.7
+# @version 0.2.8
 """
 @title Tokenized Liquidity Gauge Wrapper
 @author Curve Finance

--- a/contracts/gauges/LiquidityGaugeWrapper.vy
+++ b/contracts/gauges/LiquidityGaugeWrapper.vy
@@ -195,6 +195,7 @@ def deposit(_value: uint256, addr: address = msg.sender):
         LiquidityGauge(self.gauge).deposit(_value)
 
     log Deposit(addr, _value)
+    log Transfer(ZERO_ADDRESS, addr, _value)
 
 
 @external
@@ -214,6 +215,7 @@ def withdraw(_value: uint256):
         ERC20(self.lp_token).transfer(msg.sender, _value)
 
     log Withdraw(msg.sender, _value)
+    log Transfer(msg.sender, ZERO_ADDRESS, _value)
 
 
 @view


### PR DESCRIPTION
### What I did
Add a `Transfer` event to the `deposit` and `withdraw` functions of the tokenized gauge contracts. Without this, balances will not properly show in etherscan :scream: 