### PR TITLE
Gauge ownership proxy

### DIFF
--- a/contracts/GaugeProxy.vy
+++ b/contracts/GaugeProxy.vy
@@ -1,0 +1,119 @@
+# @version 0.2.8
+"""
+@title Curve LiquidityGaugeV2 Ownerhip Proxy
+@author Curve Finance
+@license MIT
+"""
+
+interface LiquidityGauge:
+    def set_rewards(_reward_contract: address, _sigs: bytes32, _reward_tokens: address[8]): nonpayable
+    def set_killed(_is_killed: bool): nonpayable
+    def commit_transfer_ownership(addr: address): nonpayable
+    def accept_transfer_ownership(): nonpayable
+
+
+event CommitAdmins:
+    ownership_admin: address
+    emergency_admin: address
+
+event ApplyAdmins:
+    ownership_admin: address
+    emergency_admin: address
+
+
+ownership_admin: public(address)
+emergency_admin: public(address)
+
+future_ownership_admin: public(address)
+future_emergency_admin: public(address)
+
+
+@external
+def __init__(_ownership_admin: address, _emergency_admin: address):
+    self.ownership_admin = _ownership_admin
+    self.emergency_admin = _emergency_admin
+
+
+@external
+def commit_set_admins(_o_admin: address, _e_admin: address):
+    """
+    @notice Set ownership admin to `_o_admin` and emergency admin to `_e_admin`
+    @param _o_admin Ownership admin
+    @param _e_admin Emergency admin
+    """
+    assert msg.sender == self.ownership_admin, "Access denied"
+
+    self.future_ownership_admin = _o_admin
+    self.future_emergency_admin = _e_admin
+
+    log CommitAdmins(_o_admin, _e_admin)
+
+
+@external
+def accept_set_admins():
+    """
+    @notice Apply the effects of `commit_set_admins`
+    @dev Only callable by the new owner admin
+    """
+    assert msg.sender == self.future_ownership_admin, "Access denied"
+
+    e_admin: address = self.future_emergency_admin
+    self.ownership_admin = msg.sender
+    self.emergency_admin = e_admin
+
+    log ApplyAdmins(msg.sender, e_admin)
+
+
+@external
+@nonreentrant('lock')
+def commit_transfer_ownership(_gauge: address, new_owner: address):
+    """
+    @notice Transfer ownership for liquidity gauge `_gauge` to `new_owner`
+    @param _gauge Gauge which ownership is to be transferred
+    @param new_owner New gauge owner address
+    """
+    assert msg.sender == self.ownership_admin, "Access denied"
+    LiquidityGauge(_gauge).commit_transfer_ownership(new_owner)
+
+
+@external
+@nonreentrant('lock')
+def accept_transfer_ownership(_gauge: address):
+    """
+    @notice Apply transferring ownership of `_gauge`
+    @param _gauge Gauge address
+    """
+    LiquidityGauge(_gauge).accept_transfer_ownership()
+
+
+@external
+@nonreentrant('lock')
+def set_killed(_gauge: address, _is_killed: bool):
+    """
+    @notice Set the killed status for `_gauge`
+    @dev When killed, the gauge always yields a rate of 0 and so cannot mint CRV
+    @param _gauge Gauge address
+    @param _is_killed Killed status to set
+    """
+    assert msg.sender in [self.ownership_admin, self.emergency_admin], "Access denied"
+
+    LiquidityGauge(_gauge).set_killed(_is_killed)
+
+
+@external
+@nonreentrant('lock')
+def set_rewards(_gauge: address, _reward_contract: address, _sigs: bytes32, _reward_tokens: address[8]):
+    """
+    @notice Set the active reward contract for `_gauge`
+    @param _gauge Gauge address
+    @param _reward_contract Reward contract address. Set to ZERO_ADDRESS to
+                            disable staking.
+    @param _sigs Four byte selectors for staking, withdrawing and claiming,
+                 right padded with zero bytes. If the reward contract can
+                 be claimed from but does not require staking, the staking
+                 and withdraw selectors should be set to 0x00
+    @param _reward_tokens List of claimable tokens for this reward contract
+    """
+    assert msg.sender == self.ownership_admin, "Access denied"
+
+    LiquidityGauge(_gauge).set_rewards(_reward_contract, _sigs, _reward_tokens)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,11 @@ def pool_proxy(PoolProxy, accounts):
 
 
 @pytest.fixture(scope="module")
+def gauge_proxy(GaugeProxy, alice, bob):
+    yield GaugeProxy.deploy(alice, bob, {'from': alice})
+
+
+@pytest.fixture(scope="module")
 def coin_reward(ERC20, accounts):
     yield ERC20.deploy("YFIIIIII Funance", "YFIIIIII", 18, {'from': accounts[0]})
 

--- a/tests/unitary/GaugeProxy/test_gauge_ownership.py
+++ b/tests/unitary/GaugeProxy/test_gauge_ownership.py
@@ -1,0 +1,27 @@
+import brownie
+import pytest
+
+
+@pytest.mark.parametrize('idx', range(4))
+def test_accept_transfer_ownership(alice, accounts, gauge_proxy, gauge_v2, idx):
+    # parametrized becuase anyone should be able to call to accept
+    gauge_v2.commit_transfer_ownership(gauge_proxy, {'from': alice})
+    gauge_proxy.accept_transfer_ownership(gauge_v2, {'from': accounts[idx]})
+
+    assert gauge_v2.admin() == gauge_proxy
+
+
+def test_commit_transfer_ownership(alice, bob, gauge_proxy, gauge_v2):
+    gauge_v2.commit_transfer_ownership(gauge_proxy, {'from': alice})
+    gauge_proxy.accept_transfer_ownership(gauge_v2, {'from': alice})
+    gauge_proxy.commit_transfer_ownership(gauge_v2, bob, {'from': alice})
+
+    assert gauge_v2.future_admin() == bob
+
+
+@pytest.mark.parametrize('idx', range(1, 4))
+def test_commit_only_owner(alice, accounts, gauge_proxy, gauge_v2, idx):
+    gauge_v2.commit_transfer_ownership(gauge_proxy, {'from': alice})
+    gauge_proxy.accept_transfer_ownership(gauge_v2, {'from': alice})
+    with brownie.reverts("Access denied"):
+        gauge_proxy.commit_transfer_ownership(gauge_v2, alice, {'from': accounts[idx]})

--- a/tests/unitary/GaugeProxy/test_gauge_proxy_set_admins.py
+++ b/tests/unitary/GaugeProxy/test_gauge_proxy_set_admins.py
@@ -1,0 +1,46 @@
+import brownie
+import pytest
+from brownie import ZERO_ADDRESS
+
+
+def test_assumptions(gauge_proxy, alice, bob):
+    assert gauge_proxy.ownership_admin() == alice
+    assert gauge_proxy.emergency_admin() == bob
+
+    assert gauge_proxy.future_ownership_admin() == ZERO_ADDRESS
+    assert gauge_proxy.future_emergency_admin() == ZERO_ADDRESS
+
+
+def test_commit_set_admin(gauge_proxy, alice, bob, charlie):
+    gauge_proxy.commit_set_admins(bob, charlie, {'from': alice})
+
+    assert gauge_proxy.ownership_admin() == alice
+    assert gauge_proxy.emergency_admin() == bob
+
+    assert gauge_proxy.future_ownership_admin() == bob
+    assert gauge_proxy.future_emergency_admin() == charlie
+
+
+def test_accept_set_admin(gauge_proxy, alice, bob, charlie):
+    gauge_proxy.commit_set_admins(bob, charlie, {'from': alice})
+    gauge_proxy.accept_set_admins({'from': bob})
+
+    assert gauge_proxy.ownership_admin() == bob
+    assert gauge_proxy.emergency_admin() == charlie
+
+    assert gauge_proxy.future_ownership_admin() == bob
+    assert gauge_proxy.future_emergency_admin() == charlie
+
+
+@pytest.mark.parametrize('idx', range(1, 4))
+def test_commit_only_owner(accounts, alice, gauge_proxy, idx):
+    with brownie.reverts("Access denied"):
+        gauge_proxy.commit_set_admins(alice, alice, {'from': accounts[idx]})
+
+
+@pytest.mark.parametrize('idx', range(1, 4))
+def test_accept_only_owner(accounts, alice, bob, gauge_proxy, idx):
+    gauge_proxy.commit_set_admins(alice, bob, {'from': alice})
+
+    with brownie.reverts("Access denied"):
+        gauge_proxy.accept_set_admins({'from': accounts[idx]})

--- a/tests/unitary/GaugeProxy/test_set_killed_gauge_proxy.py
+++ b/tests/unitary/GaugeProxy/test_set_killed_gauge_proxy.py
@@ -1,0 +1,24 @@
+import brownie
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup(alice, gauge_proxy, gauge_v2, mock_lp_token):
+    gauge_v2.commit_transfer_ownership(gauge_proxy, {'from': alice})
+    gauge_proxy.accept_transfer_ownership(gauge_v2, {'from': alice})
+
+
+@pytest.mark.parametrize("is_killed", [True, False])
+@pytest.mark.parametrize("idx", range(2))
+def test_kill(accounts, gauge_proxy, gauge_v2, is_killed, idx):
+    gauge_proxy.set_killed(gauge_v2, is_killed, {'from': accounts[idx]})
+
+    assert gauge_v2.is_killed() == is_killed
+
+
+
+@pytest.mark.parametrize("is_killed", [True, False])
+@pytest.mark.parametrize("idx", range(2, 4))
+def test_only_owner(accounts, gauge_proxy, gauge_v2, is_killed, idx):
+    with brownie.reverts():
+        gauge_proxy.set_killed(gauge_v2, is_killed, {'from': accounts[idx]})

--- a/tests/unitary/GaugeProxy/test_set_rewards_gauge_proxy.py
+++ b/tests/unitary/GaugeProxy/test_set_rewards_gauge_proxy.py
@@ -1,0 +1,43 @@
+import brownie
+import pytest
+from brownie import ZERO_ADDRESS
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup(alice, gauge_proxy, gauge_v2, mock_lp_token):
+    gauge_v2.commit_transfer_ownership(gauge_proxy, {'from': alice})
+    gauge_proxy.accept_transfer_ownership(gauge_v2, {'from': alice})
+    mock_lp_token.approve(gauge_v2, 10**18, {'from': alice})
+    gauge_v2.deposit(10**18, {'from': alice})
+
+
+def test_set_rewards(alice, gauge_proxy, gauge_v2, reward_contract, coin_reward):
+    sigs = [
+        reward_contract.stake.signature[2:],
+        reward_contract.withdraw.signature[2:],
+        reward_contract.getReward.signature[2:]
+    ]
+    sigs = f"0x{sigs[0]}{sigs[1]}{sigs[2]}{'00' * 20}"
+
+    gauge_proxy.set_rewards(
+        gauge_v2,
+        reward_contract,
+        sigs,
+        [coin_reward] + [ZERO_ADDRESS] * 7,
+        {'from': alice}
+    )
+    assert gauge_v2.reward_contract() == reward_contract
+    assert gauge_v2.reward_tokens(0) == coin_reward
+
+
+@pytest.mark.parametrize('idx', [1, 2])
+def test_only_ownership_admin(accounts, gauge_proxy, gauge_v2, reward_contract, idx):
+
+    with brownie.reverts("Access denied"):
+        gauge_proxy.set_rewards(
+            gauge_v2,
+            reward_contract,
+            "0x00",
+            [ZERO_ADDRESS] * 8,
+            {'from': accounts[idx]}
+        )


### PR DESCRIPTION
### What I did
Build a proxy contract to allow the DAO to own `LiquidityGaugeV2` deployments.

### TODO
- [x] unit tests