### PR TITLE
Eth burner updates

### DIFF
--- a/contracts/burners/ETHBurner.vy
+++ b/contracts/burners/ETHBurner.vy
@@ -1,4 +1,4 @@
-# @version 0.2.7
+# @version 0.2.8
 """
 @title Synth Burner
 @notice Converts ETH denominated coins to USDC and transfers to `UnderlyingBurner`

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,7 @@ def charlie(accounts):
 
 @pytest.fixture(scope="session")
 def receiver(accounts):
-    yield accounts[3]
+    yield accounts.at("0x0000000000000000000000000000000000031337", True)
 
 
 # core contracts

--- a/tests/fork/Burners/test_eth_burner.py
+++ b/tests/fork/Burners/test_eth_burner.py
@@ -38,7 +38,6 @@ def test_swap(MintableTestToken, SUSD, alice, receiver, burner, token, burner_ba
         assert SUSD.balanceOf(receiver) == 0
 
 
-@pytest.mark.skip(reason="eth pool is not live yet")
 def test_swap_ether(MintableTestToken, SUSD, alice, receiver, burner):
     burner.burn(ETH_ADDRESS, {'from': alice, 'value': "1 ether"})
 


### PR DESCRIPTION
### What I did
* bump vyper version
* enable the fork test for ETH - it was previously skipped because eth swaps weren't possible while the pool was undeployed