### PR TITLE
Integrate brownie-token-tester

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 19.10b0
     hooks:
     -   id: black
 -   repo: https://gitlab.com/pycqa/flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,16 @@
 repos:
-    -   repo: https://github.com/psf/black
-        rev: 19.3b0
-        hooks:
-        -   id: black
-    -   repo: https://github.com/pre-commit/pre-commit-hooks
-        rev: v2.4.0
-        hooks:
-        -   id: flake8
-    -   repo: https://github.com/pre-commit/mirrors-isort
-        rev: v4.3.21
-        hooks:
-        -    id: isort
+-   repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+    -   id: black
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.4
+    hooks:
+    -   id: flake8
+-   repo: https://github.com/PyCQA/isort
+    rev: 5.7.0
+    hooks:
+    -    id: isort
 
-    default_language_version:
-        python: python3.8
+default_language_version:
+    python: python3.8

--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ View the [documentation](doc/readme.pdf) for a more in-depth explanation of how 
 
 ### Dependencies
 
-* [python3](https://www.python.org/downloads/release/python-368/) version 3.6 or greater, python3-dev
-* [vyper](https://github.com/vyperlang/vyper) version [0.2.4](https://github.com/vyperlang/vyper/releases/tag/v0.2.4)
-* [brownie](https://github.com/iamdefinitelyahuman/brownie) - tested with version [1.13.0](https://github.com/eth-brownie/brownie/releases/tag/v1.13.0)
-* [ganache-cli](https://github.com/trufflesuite/ganache-cli) - tested with version [6.12.1](https://github.com/trufflesuite/ganache-cli/releases/tag/v6.12.1)
+- [python3](https://www.python.org/downloads/release/python-368/) version 3.6 or greater, python3-dev
+- [vyper](https://github.com/vyperlang/vyper) version [0.2.4](https://github.com/vyperlang/vyper/releases/tag/v0.2.4)
+- [brownie](https://github.com/iamdefinitelyahuman/brownie) - tested with version [1.13.0](https://github.com/eth-brownie/brownie/releases/tag/v1.13.0)
+- [brownie-token-tester](https://github.com/iamdefinitelyahuman/brownie-token-tester) - tested with version [0.1.0](https://github.com/iamdefinitelyahuman/brownie-token-tester/releases/tag/v0.1.0)
+- [ganache-cli](https://github.com/trufflesuite/ganache-cli) - tested with version [6.12.1](https://github.com/trufflesuite/ganache-cli/releases/tag/v6.12.1)
 
 ### Setup
 
@@ -64,9 +65,9 @@ You may find the following guides useful:
 
 If you have any questions about this project, or wish to engage with us:
 
-* [Telegram](https://t.me/curvefi)
-* [Twitter](https://twitter.com/curvefinance)
-* [Discord](https://discord.gg/rgrfS7W)
+- [Telegram](https://t.me/curvefi)
+- [Twitter](https://twitter.com/curvefinance)
+- [Discord](https://discord.gg/rgrfS7W)
 
 ## License
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-black==19.10b0
+black==20.8b1
 eth-brownie>=1.13.0,<2.0.0
-flake8==3.7.9
-isort==4.3.21
+flake8==3.8.4
+isort==5.7.0
+brownie-token-tester>=0.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-black==20.8b1
+black==19.10b0
 eth-brownie>=1.13.0,<2.0.0
 flake8==3.8.4
 isort==5.7.0

--- a/scripts/stats/gini.py
+++ b/scripts/stats/gini.py
@@ -1,8 +1,7 @@
-import requests
-from brownie import web3
-
 import numpy as np
 import pylab
+import requests
+from brownie import web3
 
 START_BLOCK = 10647813 + 86400
 graph_url = "https://api.thegraph.com/subgraphs/name/pengiundev/curve-votingescrow3"

--- a/scripts/stats/plot_vecrv.py
+++ b/scripts/stats/plot_vecrv.py
@@ -1,7 +1,6 @@
-from brownie import Contract, web3
-
 import numpy as np
 import pylab
+from brownie import Contract, web3
 
 START_BLOCK = 10647813
 

--- a/scripts/stats/show_weekly_fees.py
+++ b/scripts/stats/show_weekly_fees.py
@@ -1,9 +1,8 @@
 from datetime import datetime
 from time import time
 
-from brownie import Contract
-
 import pylab  # Requires matplotlib
+from brownie import Contract
 
 WEEK = 86400 * 7
 

--- a/tests/fork/conftest.py
+++ b/tests/fork/conftest.py
@@ -1,53 +1,10 @@
 import pytest
-import requests
-from brownie import Contract
-from brownie.convert import to_address
-
-_holders = {}
+from brownie_tokens import MintableForkToken
 
 
-class _MintableTestToken(Contract):
+class _MintableTestToken(MintableForkToken):
     def __init__(self, address):
         super().__init__(address)
-
-        # get top token holder addresses
-        address = self.address
-        if address not in _holders:
-            holders = requests.get(
-                f"https://api.ethplorer.io/getTopTokenHolders/{address}",
-                params={"apiKey": "freekey", "limit": 50},
-            ).json()
-            _holders[address] = [to_address(i["address"]) for i in holders["holders"]]
-
-    def _mint_for_testing(self, target, amount, tx=None):
-        if self.address == "0x674C6Ad92Fd080e4004b2312b45f796a192D27a0":
-            # USDN
-            self.deposit(target, amount, {"from": "0x90f85042533F11b362769ea9beE20334584Dcd7D"})
-            return
-        if self.address == "0x0E2EC54fC0B509F445631Bf4b91AB8168230C752":
-            # LinkUSD
-            self.mint(target, amount, {"from": "0x62F31E08e279f3091d9755a09914DF97554eAe0b"})
-            return
-        if self.address == "0x196f4727526eA7FB1e17b2071B3d8eAA38486988":
-            # RSV
-            self.changeMaxSupply(2 ** 128, {"from": self.owner()})
-            self.mint(target, amount, {"from": self.minter()})
-            return
-
-        for address in _holders[self.address].copy():
-            if address == self.address:
-                # don't claim from the treasury - that could cause wierdness
-                continue
-
-            balance = self.balanceOf(address)
-            if amount > balance:
-                self.transfer(target, balance, {"from": address})
-                amount -= balance
-            else:
-                self.transfer(target, amount, {"from": address})
-                return
-
-        raise ValueError(f"Insufficient tokens available to mint {self.name()}")
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## What did I do?

Small PR for integrating [`brownie-token-tester`](https://github.com/iamdefinitelyahuman/brownie-token-tester) and remove redundant logic for custom ERC20 minting in tests. Also bumped versions for `isort` (removes `unknown_third_party` issues) and `flake`.

#### Why is this needed? 

Integrating `brownie-token-tester` across Curve repos will take out a lot of duplicated logic, as well as make it easier to add and test custom ERC20 minting logic.
