### PR TITLE
Gauge wrapper for Unit.xyz

### DIFF
--- a/contracts/gauges/LiquidityGaugeWrapperUnit.vy
+++ b/contracts/gauges/LiquidityGaugeWrapperUnit.vy
@@ -1,0 +1,360 @@
+# @version 0.2.8
+"""
+@title Tokenized Liquidity Gauge Wrapper
+@author Curve Finance
+@license MIT
+@notice Allows tokenized deposits and claiming from `LiquidityGauge`
+"""
+
+from vyper.interfaces import ERC20
+
+implements: ERC20
+
+interface LiquidityGauge:
+    def lp_token() -> address: view
+    def minter() -> address: view
+    def crv_token() -> address: view
+    def deposit(_value: uint256): nonpayable
+    def withdraw(_value: uint256): nonpayable
+    def claimable_tokens(addr: address) -> uint256: nonpayable
+
+interface Minter:
+    def mint(gauge_addr: address): nonpayable
+
+
+event Deposit:
+    provider: indexed(address)
+    value: uint256
+
+event Withdraw:
+    provider: indexed(address)
+    value: uint256
+
+event CommitOwnership:
+    admin: address
+
+event ApplyOwnership:
+    admin: address
+
+event Transfer:
+    _from: indexed(address)
+    _to: indexed(address)
+    _value: uint256
+
+event Approval:
+    _owner: indexed(address)
+    _spender: indexed(address)
+    _value: uint256
+
+
+minter: public(address)
+crv_token: public(address)
+lp_token: public(address)
+gauge: public(address)
+
+balanceOf: public(HashMap[address, uint256])
+totalSupply: public(uint256)
+allowances: HashMap[address, HashMap[address, uint256]]
+
+name: public(String[64])
+symbol: public(String[32])
+decimals: public(uint256)
+
+# caller -> recipient -> can deposit?
+approved_to_deposit: public(HashMap[address, HashMap[address, bool]])
+
+crv_integral: uint256
+crv_integral_for: HashMap[address, uint256]
+claimable_crv: public(HashMap[address, uint256])
+
+admin: public(address)
+future_admin: public(address)
+is_killed: public(bool)
+
+
+@external
+def __init__(
+    _name: String[64],
+    _symbol: String[32],
+    _gauge: address,
+    _admin: address
+):
+    """
+    @notice Contract constructor
+    @param _name Token full name
+    @param _symbol Token symbol
+    @param _gauge Liquidity gauge contract address
+    @param _admin Admin who can kill the gauge
+    """
+
+    self.name = _name
+    self.symbol = _symbol
+    self.decimals = 18
+
+    lp_token: address = LiquidityGauge(_gauge).lp_token()
+    ERC20(lp_token).approve(_gauge, MAX_UINT256)
+
+    self.minter = LiquidityGauge(_gauge).minter()
+    self.crv_token = LiquidityGauge(_gauge).crv_token()
+    self.lp_token = lp_token
+    self.gauge = _gauge
+    self.admin = _admin
+
+
+@internal
+def _checkpoint(addr: address):
+    crv_token: address = self.crv_token
+
+    d_reward: uint256 = ERC20(crv_token).balanceOf(self)
+    Minter(self.minter).mint(self.gauge)
+    d_reward = ERC20(crv_token).balanceOf(self) - d_reward
+
+    total_balance: uint256 = self.totalSupply
+    dI: uint256 = 0
+    if total_balance > 0:
+        dI = 10 ** 18 * d_reward / total_balance
+    I: uint256 = self.crv_integral + dI
+    self.crv_integral = I
+    self.claimable_crv[addr] += self.balanceOf[addr] * (I - self.crv_integral_for[addr]) / 10 ** 18
+    self.crv_integral_for[addr] = I
+
+
+@external
+def user_checkpoint(addr: address) -> bool:
+    """
+    @notice Record a checkpoint for `addr`
+    @param addr User address
+    @return bool success
+    """
+    assert msg.sender == addr or msg.sender == self.minter  # dev: unauthorized
+    self._checkpoint(addr)
+    return True
+
+
+@external
+def claimable_tokens(addr: address) -> uint256:
+    """
+    @notice Get the number of claimable tokens per user
+    @dev This function should be manually changed to "view" in the ABI
+    @return uint256 number of claimable tokens per user
+    """
+    d_reward: uint256 = LiquidityGauge(self.gauge).claimable_tokens(self)
+
+    total_balance: uint256 = self.totalSupply
+    dI: uint256 = 0
+    if total_balance > 0:
+        dI = 10 ** 18 * d_reward / total_balance
+    I: uint256 = self.crv_integral + dI
+
+    return self.claimable_crv[addr] + self.balanceOf[addr] * (I - self.crv_integral_for[addr]) / 10 ** 18
+
+
+@external
+@nonreentrant('lock')
+def claim_tokens(addr: address = msg.sender):
+    """
+    @notice Claim mintable CR
+    @param addr Address to claim for
+    """
+    self._checkpoint(addr)
+    ERC20(self.crv_token).transfer(addr, self.claimable_crv[addr])
+
+    self.claimable_crv[addr] = 0
+
+
+@external
+def set_approve_deposit(addr: address, can_deposit: bool):
+    """
+    @notice Set whether `addr` can deposit tokens for `msg.sender`
+    @param addr Address to set approval on
+    @param can_deposit bool - can this account deposit for `msg.sender`?
+    """
+    self.approved_to_deposit[addr][msg.sender] = can_deposit
+
+
+@external
+@nonreentrant('lock')
+def deposit(_value: uint256, addr: address = msg.sender):
+    """
+    @notice Deposit `_value` LP tokens
+    @param _value Number of tokens to deposit
+    @param addr Address to deposit for
+    """
+    assert not self.is_killed
+
+    if addr != msg.sender:
+        assert self.approved_to_deposit[msg.sender][addr], "Not approved"
+
+    self._checkpoint(addr)
+
+    if _value != 0:
+        self.balanceOf[addr] += _value
+        self.totalSupply += _value
+
+        ERC20(self.lp_token).transferFrom(msg.sender, self, _value)
+        LiquidityGauge(self.gauge).deposit(_value)
+
+    log Deposit(addr, _value)
+    log Transfer(ZERO_ADDRESS, addr, _value)
+
+
+@external
+@nonreentrant('lock')
+def withdraw(_value: uint256):
+    """
+    @notice Withdraw `_value` LP tokens
+    @param _value Number of tokens to withdraw
+    """
+    self._checkpoint(msg.sender)
+
+    if _value != 0:
+        self.balanceOf[msg.sender] -= _value
+        self.totalSupply -= _value
+
+        LiquidityGauge(self.gauge).withdraw(_value)
+        ERC20(self.lp_token).transfer(msg.sender, _value)
+
+    log Withdraw(msg.sender, _value)
+    log Transfer(msg.sender, ZERO_ADDRESS, _value)
+
+
+@view
+@external
+def allowance(_owner : address, _spender : address) -> uint256:
+    """
+    @dev Function to check the amount of tokens that an owner allowed to a spender.
+    @param _owner The address which owns the funds.
+    @param _spender The address which will spend the funds.
+    @return An uint256 specifying the amount of tokens still available for the spender.
+    """
+    return self.allowances[_owner][_spender]
+
+
+@internal
+def _transfer(_from: address, _to: address, _value: uint256):
+    assert not self.is_killed
+
+    self._checkpoint(_from)
+    self._checkpoint(_to)
+
+    if _value != 0:
+        self.balanceOf[_from] -= _value
+        self.balanceOf[_to] += _value
+
+    log Transfer(_from, _to, _value)
+
+
+@external
+@nonreentrant('lock')
+def transfer(_to : address, _value : uint256) -> bool:
+    """
+    @dev Transfer token for a specified address
+    @param _to The address to transfer to.
+    @param _value The amount to be transferred.
+    """
+    self._transfer(msg.sender, _to, _value)
+
+    return True
+
+
+@external
+@nonreentrant('lock')
+def transferFrom(_from : address, _to : address, _value : uint256) -> bool:
+    """
+     @dev Transfer tokens from one address to another.
+     @param _from address The address which you want to send tokens from
+     @param _to address The address which you want to transfer to
+     @param _value uint256 the amount of tokens to be transferred
+    """
+    _allowance: uint256 = self.allowances[_from][msg.sender]
+    if _allowance != MAX_UINT256:
+        self.allowances[_from][msg.sender] = _allowance - _value
+
+    self._transfer(_from, _to, _value)
+
+    return True
+
+
+@external
+def approve(_spender : address, _value : uint256) -> bool:
+    """
+    @notice Approve the passed address to transfer the specified amount of
+            tokens on behalf of msg.sender
+    @dev Beware that changing an allowance via this method brings the risk
+         that someone may use both the old and new allowance by unfortunate
+         transaction ordering. This may be mitigated with the use of
+         {increaseAllowance} and {decreaseAllowance}.
+         https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+    @param _spender The address which will transfer the funds
+    @param _value The amount of tokens that may be transferred
+    @return bool success
+    """
+    self.allowances[msg.sender][_spender] = _value
+    log Approval(msg.sender, _spender, _value)
+
+    return True
+
+
+@external
+def increaseAllowance(_spender: address, _added_value: uint256) -> bool:
+    """
+    @notice Increase the allowance granted to `_spender` by the caller
+    @dev This is alternative to {approve} that can be used as a mitigation for
+         the potential race condition
+    @param _spender The address which will transfer the funds
+    @param _added_value The amount of to increase the allowance
+    @return bool success
+    """
+    allowance: uint256 = self.allowances[msg.sender][_spender] + _added_value
+    self.allowances[msg.sender][_spender] = allowance
+
+    log Approval(msg.sender, _spender, allowance)
+
+    return True
+
+
+@external
+def decreaseAllowance(_spender: address, _subtracted_value: uint256) -> bool:
+    """
+    @notice Decrease the allowance granted to `_spender` by the caller
+    @dev This is alternative to {approve} that can be used as a mitigation for
+         the potential race condition
+    @param _spender The address which will transfer the funds
+    @param _subtracted_value The amount of to decrease the allowance
+    @return bool success
+    """
+    allowance: uint256 = self.allowances[msg.sender][_spender] - _subtracted_value
+    self.allowances[msg.sender][_spender] = allowance
+
+    log Approval(msg.sender, _spender, allowance)
+
+    return True
+
+
+@external
+def kill_me():
+    assert msg.sender == self.admin
+    self.is_killed = not self.is_killed
+
+
+@external
+def commit_transfer_ownership(addr: address):
+    """
+    @notice Transfer ownership of GaugeController to `addr`
+    @param addr Address to have ownership transferred to
+    """
+    assert msg.sender == self.admin  # dev: admin only
+    self.future_admin = addr
+    log CommitOwnership(addr)
+
+
+@external
+def apply_transfer_ownership():
+    """
+    @notice Apply pending ownership transfer
+    """
+    assert msg.sender == self.admin  # dev: admin only
+    _admin: address = self.future_admin
+    assert _admin != ZERO_ADDRESS  # dev: admin not set
+    self.admin = _admin
+    log ApplyOwnership(_admin)

--- a/contracts/gauges/LiquidityGaugeWrapperUnit.vy
+++ b/contracts/gauges/LiquidityGaugeWrapperUnit.vy
@@ -74,7 +74,6 @@ claimable_crv: public(HashMap[address, uint256])
 
 admin: public(address)
 future_admin: public(address)
-is_killed: public(bool)
 
 # [uint216 claimable balance][uint40 timestamp]
 last_claim_data: uint256
@@ -143,7 +142,6 @@ def user_checkpoint(addr: address) -> bool:
     @param addr User address
     @return bool success
     """
-    assert msg.sender == addr or msg.sender == self.minter  # dev: unauthorized
     self._checkpoint([addr, ZERO_ADDRESS])
     return True
 
@@ -198,8 +196,6 @@ def deposit(_value: uint256, addr: address = msg.sender):
     @param _value Number of tokens to deposit
     @param addr Address to deposit for
     """
-    assert not self.is_killed
-
     if addr != msg.sender:
         assert self.approved_to_deposit[msg.sender][addr], "Not approved"
 
@@ -250,8 +246,6 @@ def allowance(_owner : address, _spender : address) -> uint256:
 
 @internal
 def _transfer(_from: address, _to: address, _value: uint256):
-    assert not self.is_killed
-
     self._checkpoint([_from, _to])
 
     if _value != 0:
@@ -352,12 +346,6 @@ def decreaseAllowance(_spender: address, _subtracted_value: uint256) -> bool:
     log Approval(msg.sender, _spender, allowance)
 
     return True
-
-
-@external
-def kill_me():
-    assert msg.sender == self.admin
-    self.is_killed = not self.is_killed
 
 
 @external

--- a/contracts/gauges/LiquidityGaugeWrapperUnit.vy
+++ b/contracts/gauges/LiquidityGaugeWrapperUnit.vy
@@ -58,7 +58,6 @@ allowances: HashMap[address, HashMap[address, uint256]]
 
 name: public(String[64])
 symbol: public(String[32])
-decimals: public(uint256)
 
 # caller -> recipient -> can deposit?
 approved_to_deposit: public(HashMap[address, HashMap[address, bool]])
@@ -89,7 +88,6 @@ def __init__(
 
     self.name = _name
     self.symbol = _symbol
-    self.decimals = 18
 
     lp_token: address = LiquidityGauge(_gauge).lp_token()
     ERC20(lp_token).approve(_gauge, MAX_UINT256)
@@ -98,6 +96,11 @@ def __init__(
     self.crv_token = LiquidityGauge(_gauge).crv_token()
     self.lp_token = lp_token
     self.gauge = _gauge
+
+
+@external
+def decimals() -> uint256:
+    return 18
 
 
 @internal

--- a/contracts/gauges/LiquidityGaugeWrapperUnit.vy
+++ b/contracts/gauges/LiquidityGaugeWrapperUnit.vy
@@ -35,12 +35,6 @@ event Withdraw:
     provider: indexed(address)
     value: uint256
 
-event CommitOwnership:
-    admin: address
-
-event ApplyOwnership:
-    admin: address
-
 event Transfer:
     _from: indexed(address)
     _to: indexed(address)
@@ -73,9 +67,6 @@ crv_integral: uint256
 crv_integral_for: HashMap[address, uint256]
 claimable_crv: public(HashMap[address, uint256])
 
-admin: public(address)
-future_admin: public(address)
-
 # [uint216 claimable balance][uint40 timestamp]
 last_claim_data: uint256
 
@@ -88,14 +79,12 @@ def __init__(
     _name: String[64],
     _symbol: String[32],
     _gauge: address,
-    _admin: address
 ):
     """
     @notice Contract constructor
     @param _name Token full name
     @param _symbol Token symbol
     @param _gauge Liquidity gauge contract address
-    @param _admin Admin who can kill the gauge
     """
 
     self.name = _name
@@ -109,7 +98,6 @@ def __init__(
     self.crv_token = LiquidityGauge(_gauge).crv_token()
     self.lp_token = lp_token
     self.gauge = _gauge
-    self.admin = _admin
 
 
 @internal
@@ -353,26 +341,3 @@ def decreaseAllowance(_spender: address, _subtracted_value: uint256) -> bool:
     log Approval(msg.sender, _spender, allowance)
 
     return True
-
-
-@external
-def commit_transfer_ownership(addr: address):
-    """
-    @notice Transfer ownership of GaugeController to `addr`
-    @param addr Address to have ownership transferred to
-    """
-    assert msg.sender == self.admin  # dev: admin only
-    self.future_admin = addr
-    log CommitOwnership(addr)
-
-
-@external
-def apply_transfer_ownership():
-    """
-    @notice Apply pending ownership transfer
-    """
-    assert msg.sender == self.admin  # dev: admin only
-    _admin: address = self.future_admin
-    assert _admin != ZERO_ADDRESS  # dev: admin not set
-    self.admin = _admin
-    log ApplyOwnership(_admin)

--- a/contracts/testing/UnitVault.vy
+++ b/contracts/testing/UnitVault.vy
@@ -1,0 +1,32 @@
+# @version 0.2.11
+
+from vyper.interfaces import ERC20
+
+# asset -> owner -> amount
+collaterals: public(HashMap[address, HashMap[address, uint256]])
+
+token: address
+
+
+@external
+def set_token(_token: address):
+    self.token = _token
+
+@external
+def deposit(_amount: uint256):
+    ERC20(self.token).transferFrom(msg.sender, self, _amount)
+    self.collaterals[self.token][msg.sender] += _amount
+
+
+@external
+def withdraw(_amount: uint256):
+    self.collaterals[self.token][msg.sender] -= _amount
+    ERC20(self.token).transfer(msg.sender, _amount)
+
+
+@external
+def liquidate(_user: address, _amount: uint256):
+    total: uint256 = self.collaterals[self.token][_user]
+    self.collaterals[self.token][_user] = 0
+    ERC20(self.token).transfer(_user, total - _amount)
+    ERC20(self.token).transfer(msg.sender, _amount)

--- a/scripts/stats/show_weekly_fees.py
+++ b/scripts/stats/show_weekly_fees.py
@@ -37,6 +37,8 @@ def main():
     pylab.xlabel("Distribution date")
     pylab.ylabel("Fees distributed (USD)")
     pylab.ylim(0, max(fees) * 1.1)
-    pylab.yticks([0.2e6, 0.4e6, 0.6e6, 0.8e6, 1e6, 2e6], labels=['200k', '400k', '600k', '800k', '1M', '2M'])
+    pylab.yticks(
+        [0.2e6, 0.4e6, 0.6e6, 0.8e6, 1e6, 2e6], labels=["200k", "400k", "600k", "800k", "1M", "2M"]
+    )
     pylab.grid()
     pylab.show()

--- a/tests/unitary/LiquidityGaugeWrapperUnit/conftest.py
+++ b/tests/unitary/LiquidityGaugeWrapperUnit/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+
+
+@pytest.fixture(scope="module")
+def unit_gauge(LiquidityGaugeWrapperUnit, alice, liquidity_gauge, vault):
+    contract = LiquidityGaugeWrapperUnit.deploy(
+        "Tokenized Gauge", "TG", liquidity_gauge, {"from": alice}
+    )
+    vault.set_token(contract, {'from': alice})
+    yield contract
+
+
+@pytest.fixture(scope="module")
+def vault(UnitVault, accounts):
+    deployer = accounts.at('0xf827ac3a510eca8d7f356c9c9d78699d5848cabf', force=True)
+    # increment the nonce to our mock vault has the hardcoded address
+    for i in range(4):
+        deployer.transfer(deployer, 0)
+
+    yield UnitVault.deploy({'from': deployer})

--- a/tests/unitary/LiquidityGaugeWrapperUnit/conftest.py
+++ b/tests/unitary/LiquidityGaugeWrapperUnit/conftest.py
@@ -6,15 +6,15 @@ def unit_gauge(LiquidityGaugeWrapperUnit, alice, liquidity_gauge, vault):
     contract = LiquidityGaugeWrapperUnit.deploy(
         "Tokenized Gauge", "TG", liquidity_gauge, {"from": alice}
     )
-    vault.set_token(contract, {'from': alice})
+    vault.set_token(contract, {"from": alice})
     yield contract
 
 
 @pytest.fixture(scope="module")
 def vault(UnitVault, accounts):
-    deployer = accounts.at('0xf827ac3a510eca8d7f356c9c9d78699d5848cabf', force=True)
+    deployer = accounts.at("0xf827ac3a510eca8d7f356c9c9d78699d5848cabf", force=True)
     # increment the nonce to our mock vault has the hardcoded address
     for i in range(4):
         deployer.transfer(deployer, 0)
 
-    yield UnitVault.deploy({'from': deployer})
+    yield UnitVault.deploy({"from": deployer})

--- a/tests/unitary/LiquidityGaugeWrapperUnit/test_approve.py
+++ b/tests/unitary/LiquidityGaugeWrapperUnit/test_approve.py
@@ -1,0 +1,67 @@
+#!/usr/bin/python3
+
+import pytest
+
+
+@pytest.mark.parametrize("idx", range(5))
+def test_initial_approval_is_zero(unit_gauge, accounts, idx):
+    assert unit_gauge.allowance(accounts[0], accounts[idx]) == 0
+
+
+def test_approve(unit_gauge, accounts):
+    unit_gauge.approve(accounts[1], 10 ** 19, {"from": accounts[0]})
+
+    assert unit_gauge.allowance(accounts[0], accounts[1]) == 10 ** 19
+
+
+def test_modify_approve(unit_gauge, accounts):
+    unit_gauge.approve(accounts[1], 10 ** 19, {"from": accounts[0]})
+    unit_gauge.approve(accounts[1], 12345678, {"from": accounts[0]})
+
+    assert unit_gauge.allowance(accounts[0], accounts[1]) == 12345678
+
+
+def test_revoke_approve(unit_gauge, accounts):
+    unit_gauge.approve(accounts[1], 10 ** 19, {"from": accounts[0]})
+    unit_gauge.approve(accounts[1], 0, {"from": accounts[0]})
+
+    assert unit_gauge.allowance(accounts[0], accounts[1]) == 0
+
+
+def test_approve_self(unit_gauge, accounts):
+    unit_gauge.approve(accounts[0], 10 ** 19, {"from": accounts[0]})
+
+    assert unit_gauge.allowance(accounts[0], accounts[0]) == 10 ** 19
+
+
+def test_only_affects_target(unit_gauge, accounts):
+    unit_gauge.approve(accounts[1], 10 ** 19, {"from": accounts[0]})
+
+    assert unit_gauge.allowance(accounts[1], accounts[0]) == 0
+
+
+def test_returns_true(unit_gauge, accounts):
+    tx = unit_gauge.approve(accounts[1], 10 ** 19, {"from": accounts[0]})
+
+    assert tx.return_value is True
+
+
+def test_approval_event_fires(accounts, unit_gauge):
+    tx = unit_gauge.approve(accounts[1], 10 ** 19, {"from": accounts[0]})
+
+    assert len(tx.events) == 1
+    assert tx.events["Approval"].values() == [accounts[0], accounts[1], 10 ** 19]
+
+
+def test_increase_allowance(accounts, unit_gauge):
+    unit_gauge.approve(accounts[1], 100, {"from": accounts[0]})
+    unit_gauge.increaseAllowance(accounts[1], 403, {"from": accounts[0]})
+
+    assert unit_gauge.allowance(accounts[0], accounts[1]) == 503
+
+
+def test_decrease_allowance(accounts, unit_gauge):
+    unit_gauge.approve(accounts[1], 100, {"from": accounts[0]})
+    unit_gauge.decreaseAllowance(accounts[1], 34, {"from": accounts[0]})
+
+    assert unit_gauge.allowance(accounts[0], accounts[1]) == 66

--- a/tests/unitary/LiquidityGaugeWrapperUnit/test_checkpoint.py
+++ b/tests/unitary/LiquidityGaugeWrapperUnit/test_checkpoint.py
@@ -1,0 +1,26 @@
+import pytest
+
+YEAR = 86400 * 365
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup(accounts, gauge_controller, minter, liquidity_gauge, token):
+    token.set_minter(minter, {"from": accounts[0]})
+
+    gauge_controller.add_type(b"Liquidity", 10 ** 10, {"from": accounts[0]})
+    gauge_controller.add_gauge(liquidity_gauge, 0, 0, {"from": accounts[0]})
+
+
+def test_user_checkpoint(accounts, unit_gauge):
+    unit_gauge.user_checkpoint(accounts[1], {"from": accounts[1]})
+
+
+def test_user_checkpoint_new_period(accounts, chain, unit_gauge):
+    unit_gauge.user_checkpoint(accounts[1], {"from": accounts[1]})
+    chain.sleep(int(YEAR * 1.1))
+    unit_gauge.user_checkpoint(accounts[1], {"from": accounts[1]})
+
+
+def test_user_checkpoint_wrong_account(accounts, unit_gauge):
+    # this is allowed, because anyone can also transfer tokens to trigger
+    unit_gauge.user_checkpoint(accounts[2], {"from": accounts[1]})

--- a/tests/unitary/LiquidityGaugeWrapperUnit/test_claim_tokens.py
+++ b/tests/unitary/LiquidityGaugeWrapperUnit/test_claim_tokens.py
@@ -1,0 +1,96 @@
+import itertools
+
+import pytest
+
+TYPE_WEIGHTS = [5e17, 1e19]
+GAUGE_WEIGHTS = [1e19, 1e18, 5e17]
+GAUGE_TYPES = [0, 0, 1]
+
+MONTH = 86400 * 30
+WEEK = 7 * 86400
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup(
+    accounts, mock_lp_token, token, minter, gauge_controller, liquidity_gauge, unit_gauge,
+):
+    token.set_minter(minter, {"from": accounts[0]})
+
+    gauge_controller.add_type(b"Liquidity", 10 ** 10, {"from": accounts[0]})
+    gauge_controller.add_gauge(liquidity_gauge, 0, 10 ** 18, {"from": accounts[0]})
+
+    # transfer tokens
+    for acct in accounts[1:4]:
+        mock_lp_token.transfer(acct, 1e18, {"from": accounts[0]})
+
+    # approve gauge and wrapper
+    for gauge, acct in itertools.product([liquidity_gauge, unit_gauge], accounts[1:4]):
+        mock_lp_token.approve(gauge, 1e18, {"from": acct})
+
+
+def test_claim(accounts, chain, liquidity_gauge, unit_gauge, token):
+    unit_gauge.deposit(1e18, {"from": accounts[1]})
+
+    chain.sleep(MONTH)
+    unit_gauge.claim_tokens({"from": accounts[1]})
+    expected = liquidity_gauge.integrate_fraction(unit_gauge)
+
+    assert expected > 0
+    assert token.balanceOf(accounts[1]) == expected
+
+
+def test_multiple_depositors(accounts, chain, liquidity_gauge, unit_gauge, token):
+    unit_gauge.deposit(1e18, {"from": accounts[1]})
+
+    chain.sleep(MONTH)
+    unit_gauge.deposit(1e18, {"from": accounts[2]})
+    chain.sleep(MONTH)
+    unit_gauge.withdraw(1e18, {"from": accounts[1]})
+    unit_gauge.withdraw(1e18, {"from": accounts[2]})
+    chain.sleep(10)
+
+    unit_gauge.claim_tokens({"from": accounts[1]})
+    unit_gauge.claim_tokens({"from": accounts[2]})
+
+    expected = liquidity_gauge.integrate_fraction(unit_gauge)
+    actual = token.balanceOf(accounts[1]) + token.balanceOf(accounts[2])
+
+    assert expected > 0
+    assert 0 <= expected - actual <= 1
+
+
+def test_multiple_claims(accounts, chain, liquidity_gauge, unit_gauge, token):
+    unit_gauge.deposit(1e18, {"from": accounts[1]})
+
+    chain.sleep(MONTH)
+    unit_gauge.claim_tokens({"from": accounts[1]})
+    balance = token.balanceOf(accounts[1])
+
+    chain.sleep(MONTH)
+    unit_gauge.claim_tokens({"from": accounts[1]})
+    expected = liquidity_gauge.integrate_fraction(unit_gauge)
+    final_balance = token.balanceOf(accounts[1])
+
+    assert final_balance > balance
+    assert final_balance == expected
+
+
+def test_claim_without_deposit(accounts, chain, unit_gauge, token):
+    unit_gauge.claim_tokens({"from": accounts[1]})
+
+    assert token.balanceOf(accounts[1]) == 0
+
+
+def test_claimable_no_deposit(accounts, unit_gauge):
+    assert unit_gauge.claimable_tokens.call(accounts[1]) == 0
+
+
+def test_claimable_tokens(accounts, chain, unit_gauge, token):
+    unit_gauge.deposit(1e18, {"from": accounts[1]})
+
+    chain.sleep(MONTH)
+    chain.mine()
+    claimable = unit_gauge.claimable_tokens.call(accounts[1])
+
+    unit_gauge.claim_tokens({"from": accounts[1]})
+    assert token.balanceOf(accounts[1]) >= claimable > 0

--- a/tests/unitary/LiquidityGaugeWrapperUnit/test_deposit_withdraw.py
+++ b/tests/unitary/LiquidityGaugeWrapperUnit/test_deposit_withdraw.py
@@ -1,0 +1,118 @@
+import brownie
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def deposit_setup(
+    accounts, gauge_controller, minter, liquidity_gauge, unit_gauge, token, mock_lp_token,
+):
+    token.set_minter(minter, {"from": accounts[0]})
+
+    gauge_controller.add_type(b"Liquidity", 10 ** 10, {"from": accounts[0]})
+    gauge_controller.add_gauge(liquidity_gauge, 0, 0, {"from": accounts[0]})
+
+    mock_lp_token.approve(unit_gauge, 2 ** 256 - 1, {"from": accounts[0]})
+
+
+def test_deposit(accounts, liquidity_gauge, unit_gauge, mock_lp_token):
+    balance = mock_lp_token.balanceOf(accounts[0])
+    unit_gauge.deposit(100000, {"from": accounts[0]})
+
+    assert mock_lp_token.balanceOf(liquidity_gauge) == 100000
+    assert mock_lp_token.balanceOf(unit_gauge) == 0
+    assert mock_lp_token.balanceOf(accounts[0]) == balance - 100000
+
+    assert liquidity_gauge.totalSupply() == 100000
+    assert liquidity_gauge.balanceOf(unit_gauge) == 100000
+
+    assert unit_gauge.totalSupply() == 100000
+    assert unit_gauge.balanceOf(accounts[0]) == 100000
+
+
+def test_deposit_zero(accounts, liquidity_gauge, unit_gauge, mock_lp_token):
+    balance = mock_lp_token.balanceOf(accounts[0])
+    liquidity_gauge.deposit(0, {"from": accounts[0]})
+
+    assert mock_lp_token.balanceOf(liquidity_gauge) == 0
+    assert mock_lp_token.balanceOf(unit_gauge) == 0
+    assert mock_lp_token.balanceOf(accounts[0]) == balance
+
+    assert liquidity_gauge.totalSupply() == 0
+    assert liquidity_gauge.balanceOf(unit_gauge) == 0
+
+    assert unit_gauge.totalSupply() == 0
+    assert unit_gauge.balanceOf(accounts[0]) == 0
+
+
+def test_deposit_insufficient_balance(accounts, unit_gauge):
+    with brownie.reverts():
+        unit_gauge.deposit(100000, {"from": accounts[1]})
+
+
+def test_withdraw(accounts, liquidity_gauge, unit_gauge, mock_lp_token):
+    balance = mock_lp_token.balanceOf(accounts[0])
+
+    unit_gauge.deposit(100000, {"from": accounts[0]})
+    unit_gauge.withdraw(100000, {"from": accounts[0]})
+
+    assert mock_lp_token.balanceOf(liquidity_gauge) == 0
+    assert mock_lp_token.balanceOf(unit_gauge) == 0
+    assert mock_lp_token.balanceOf(accounts[0]) == balance
+
+    assert liquidity_gauge.totalSupply() == 0
+    assert liquidity_gauge.balanceOf(unit_gauge) == 0
+
+    assert unit_gauge.totalSupply() == 0
+    assert unit_gauge.balanceOf(accounts[0]) == 0
+
+
+def test_withdraw_zero(accounts, liquidity_gauge, unit_gauge, mock_lp_token):
+    balance = mock_lp_token.balanceOf(accounts[0])
+    unit_gauge.deposit(100000, {"from": accounts[0]})
+    unit_gauge.withdraw(0, {"from": accounts[0]})
+
+    assert mock_lp_token.balanceOf(liquidity_gauge) == 100000
+    assert mock_lp_token.balanceOf(unit_gauge) == 0
+    assert mock_lp_token.balanceOf(accounts[0]) == balance - 100000
+
+    assert liquidity_gauge.totalSupply() == 100000
+    assert liquidity_gauge.balanceOf(unit_gauge) == 100000
+
+    assert unit_gauge.totalSupply() == 100000
+    assert unit_gauge.balanceOf(accounts[0]) == 100000
+
+
+def test_withdraw_new_epoch(accounts, chain, liquidity_gauge, unit_gauge, mock_lp_token):
+    balance = mock_lp_token.balanceOf(accounts[0])
+
+    unit_gauge.deposit(100000, {"from": accounts[0]})
+    chain.sleep(86400 * 400)
+    unit_gauge.withdraw(100000, {"from": accounts[0]})
+
+    assert mock_lp_token.balanceOf(liquidity_gauge) == 0
+    assert mock_lp_token.balanceOf(unit_gauge) == 0
+    assert mock_lp_token.balanceOf(accounts[0]) == balance
+
+    assert liquidity_gauge.totalSupply() == 0
+    assert liquidity_gauge.balanceOf(unit_gauge) == 0
+
+    assert unit_gauge.totalSupply() == 0
+    assert unit_gauge.balanceOf(accounts[0]) == 0
+
+
+def test_transfer_and_withdraw(accounts, unit_gauge, mock_lp_token):
+
+    unit_gauge.deposit(100000, {"from": accounts[0]})
+    unit_gauge.transfer(accounts[1], 100000)
+    unit_gauge.withdraw(100000, {"from": accounts[1]})
+
+    assert mock_lp_token.balanceOf(accounts[1]) == 100000
+
+
+def test_cannot_withdraw_after_transfer(accounts, unit_gauge, mock_lp_token):
+
+    unit_gauge.deposit(100000, {"from": accounts[0]})
+    unit_gauge.transfer(accounts[1], 100000)
+
+    with brownie.reverts():
+        unit_gauge.withdraw(100000, {"from": accounts[0]})

--- a/tests/unitary/LiquidityGaugeWrapperUnit/test_transfer.py
+++ b/tests/unitary/LiquidityGaugeWrapperUnit/test_transfer.py
@@ -1,0 +1,93 @@
+#!/usr/bin/python3
+import brownie
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup(
+    accounts, gauge_controller, minter, liquidity_gauge, unit_gauge, token, mock_lp_token,
+):
+    token.set_minter(minter, {"from": accounts[0]})
+
+    gauge_controller.add_type(b"Liquidity", 10 ** 10, {"from": accounts[0]})
+    gauge_controller.add_gauge(liquidity_gauge, 0, 0, {"from": accounts[0]})
+
+    mock_lp_token.approve(unit_gauge, 2 ** 256 - 1, {"from": accounts[0]})
+    unit_gauge.deposit(10 ** 18, {"from": accounts[0]})
+
+
+def test_sender_balance_decreases(accounts, unit_gauge):
+    sender_balance = unit_gauge.balanceOf(accounts[0])
+    amount = sender_balance // 4
+
+    unit_gauge.transfer(accounts[1], amount, {"from": accounts[0]})
+
+    assert unit_gauge.balanceOf(accounts[0]) == sender_balance - amount
+
+
+def test_receiver_balance_increases(accounts, unit_gauge):
+    receiver_balance = unit_gauge.balanceOf(accounts[1])
+    amount = unit_gauge.balanceOf(accounts[0]) // 4
+
+    unit_gauge.transfer(accounts[1], amount, {"from": accounts[0]})
+
+    assert unit_gauge.balanceOf(accounts[1]) == receiver_balance + amount
+
+
+def test_total_supply_not_affected(accounts, unit_gauge):
+    total_supply = unit_gauge.totalSupply()
+    amount = unit_gauge.balanceOf(accounts[0])
+
+    unit_gauge.transfer(accounts[1], amount, {"from": accounts[0]})
+
+    assert unit_gauge.totalSupply() == total_supply
+
+
+def test_returns_true(accounts, unit_gauge):
+    amount = unit_gauge.balanceOf(accounts[0])
+    tx = unit_gauge.transfer(accounts[1], amount, {"from": accounts[0]})
+
+    assert tx.return_value is True
+
+
+def test_transfer_full_balance(accounts, unit_gauge):
+    amount = unit_gauge.balanceOf(accounts[0])
+    receiver_balance = unit_gauge.balanceOf(accounts[1])
+
+    unit_gauge.transfer(accounts[1], amount, {"from": accounts[0]})
+
+    assert unit_gauge.balanceOf(accounts[0]) == 0
+    assert unit_gauge.balanceOf(accounts[1]) == receiver_balance + amount
+
+
+def test_transfer_zero_tokens(accounts, unit_gauge):
+    sender_balance = unit_gauge.balanceOf(accounts[0])
+    receiver_balance = unit_gauge.balanceOf(accounts[1])
+
+    unit_gauge.transfer(accounts[1], 0, {"from": accounts[0]})
+
+    assert unit_gauge.balanceOf(accounts[0]) == sender_balance
+    assert unit_gauge.balanceOf(accounts[1]) == receiver_balance
+
+
+def test_transfer_to_self(accounts, unit_gauge):
+    sender_balance = unit_gauge.balanceOf(accounts[0])
+    amount = sender_balance // 4
+
+    unit_gauge.transfer(accounts[0], amount, {"from": accounts[0]})
+
+    assert unit_gauge.balanceOf(accounts[0]) == sender_balance
+
+
+def test_insufficient_balance(accounts, unit_gauge):
+    balance = unit_gauge.balanceOf(accounts[0])
+
+    with brownie.reverts():
+        unit_gauge.transfer(accounts[1], balance + 1, {"from": accounts[0]})
+
+
+def test_transfer_event_fires(accounts, unit_gauge):
+    amount = unit_gauge.balanceOf(accounts[0])
+    tx = unit_gauge.transfer(accounts[1], amount, {"from": accounts[0]})
+
+    assert tx.events["Transfer"].values() == [accounts[0], accounts[1], amount]

--- a/tests/unitary/LiquidityGaugeWrapperUnit/test_transferFrom.py
+++ b/tests/unitary/LiquidityGaugeWrapperUnit/test_transferFrom.py
@@ -1,0 +1,184 @@
+#!/usr/bin/python3
+import brownie
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup(
+    accounts, gauge_controller, minter, liquidity_gauge, unit_gauge, token, mock_lp_token,
+):
+    token.set_minter(minter, {"from": accounts[0]})
+
+    gauge_controller.add_type(b"Liquidity", 10 ** 10, {"from": accounts[0]})
+    gauge_controller.add_gauge(liquidity_gauge, 0, 0, {"from": accounts[0]})
+
+    mock_lp_token.approve(unit_gauge, 2 ** 256 - 1, {"from": accounts[0]})
+    unit_gauge.deposit(10 ** 18, {"from": accounts[0]})
+
+
+def test_sender_balance_decreases(accounts, unit_gauge):
+    sender_balance = unit_gauge.balanceOf(accounts[0])
+    amount = sender_balance // 4
+
+    unit_gauge.approve(accounts[1], amount, {"from": accounts[0]})
+    unit_gauge.transferFrom(accounts[0], accounts[2], amount, {"from": accounts[1]})
+
+    assert unit_gauge.balanceOf(accounts[0]) == sender_balance - amount
+
+
+def test_receiver_balance_increases(accounts, unit_gauge):
+    receiver_balance = unit_gauge.balanceOf(accounts[2])
+    amount = unit_gauge.balanceOf(accounts[0]) // 4
+
+    unit_gauge.approve(accounts[1], amount, {"from": accounts[0]})
+    unit_gauge.transferFrom(accounts[0], accounts[2], amount, {"from": accounts[1]})
+
+    assert unit_gauge.balanceOf(accounts[2]) == receiver_balance + amount
+
+
+def test_caller_balance_not_affected(accounts, unit_gauge):
+    caller_balance = unit_gauge.balanceOf(accounts[1])
+    amount = unit_gauge.balanceOf(accounts[0])
+
+    unit_gauge.approve(accounts[1], amount, {"from": accounts[0]})
+    unit_gauge.transferFrom(accounts[0], accounts[2], amount, {"from": accounts[1]})
+
+    assert unit_gauge.balanceOf(accounts[1]) == caller_balance
+
+
+def test_caller_approval_affected(accounts, unit_gauge):
+    approval_amount = unit_gauge.balanceOf(accounts[0])
+    transfer_amount = approval_amount // 4
+
+    unit_gauge.approve(accounts[1], approval_amount, {"from": accounts[0]})
+    unit_gauge.transferFrom(accounts[0], accounts[2], transfer_amount, {"from": accounts[1]})
+
+    assert unit_gauge.allowance(accounts[0], accounts[1]) == approval_amount - transfer_amount
+
+
+def test_receiver_approval_not_affected(accounts, unit_gauge):
+    approval_amount = unit_gauge.balanceOf(accounts[0])
+    transfer_amount = approval_amount // 4
+
+    unit_gauge.approve(accounts[1], approval_amount, {"from": accounts[0]})
+    unit_gauge.approve(accounts[2], approval_amount, {"from": accounts[0]})
+    unit_gauge.transferFrom(accounts[0], accounts[2], transfer_amount, {"from": accounts[1]})
+
+    assert unit_gauge.allowance(accounts[0], accounts[2]) == approval_amount
+
+
+def test_total_supply_not_affected(accounts, unit_gauge):
+    total_supply = unit_gauge.totalSupply()
+    amount = unit_gauge.balanceOf(accounts[0])
+
+    unit_gauge.approve(accounts[1], amount, {"from": accounts[0]})
+    unit_gauge.transferFrom(accounts[0], accounts[2], amount, {"from": accounts[1]})
+
+    assert unit_gauge.totalSupply() == total_supply
+
+
+def test_returns_true(accounts, unit_gauge):
+    amount = unit_gauge.balanceOf(accounts[0])
+    unit_gauge.approve(accounts[1], amount, {"from": accounts[0]})
+    tx = unit_gauge.transferFrom(accounts[0], accounts[2], amount, {"from": accounts[1]})
+
+    assert tx.return_value is True
+
+
+def test_transfer_full_balance(accounts, unit_gauge):
+    amount = unit_gauge.balanceOf(accounts[0])
+    receiver_balance = unit_gauge.balanceOf(accounts[2])
+
+    unit_gauge.approve(accounts[1], amount, {"from": accounts[0]})
+    unit_gauge.transferFrom(accounts[0], accounts[2], amount, {"from": accounts[1]})
+
+    assert unit_gauge.balanceOf(accounts[0]) == 0
+    assert unit_gauge.balanceOf(accounts[2]) == receiver_balance + amount
+
+
+def test_transfer_zero_tokens(accounts, unit_gauge):
+    sender_balance = unit_gauge.balanceOf(accounts[0])
+    receiver_balance = unit_gauge.balanceOf(accounts[2])
+
+    unit_gauge.approve(accounts[1], sender_balance, {"from": accounts[0]})
+    unit_gauge.transferFrom(accounts[0], accounts[2], 0, {"from": accounts[1]})
+
+    assert unit_gauge.balanceOf(accounts[0]) == sender_balance
+    assert unit_gauge.balanceOf(accounts[2]) == receiver_balance
+
+
+def test_transfer_zero_tokens_without_approval(accounts, unit_gauge):
+    sender_balance = unit_gauge.balanceOf(accounts[0])
+    receiver_balance = unit_gauge.balanceOf(accounts[2])
+
+    unit_gauge.transferFrom(accounts[0], accounts[2], 0, {"from": accounts[1]})
+
+    assert unit_gauge.balanceOf(accounts[0]) == sender_balance
+    assert unit_gauge.balanceOf(accounts[2]) == receiver_balance
+
+
+def test_insufficient_balance(accounts, unit_gauge):
+    balance = unit_gauge.balanceOf(accounts[0])
+
+    unit_gauge.approve(accounts[1], balance + 1, {"from": accounts[0]})
+    with brownie.reverts():
+        unit_gauge.transferFrom(accounts[0], accounts[2], balance + 1, {"from": accounts[1]})
+
+
+def test_insufficient_approval(accounts, unit_gauge):
+    balance = unit_gauge.balanceOf(accounts[0])
+
+    unit_gauge.approve(accounts[1], balance - 1, {"from": accounts[0]})
+    with brownie.reverts():
+        unit_gauge.transferFrom(accounts[0], accounts[2], balance, {"from": accounts[1]})
+
+
+def test_no_approval(accounts, unit_gauge):
+    balance = unit_gauge.balanceOf(accounts[0])
+
+    with brownie.reverts():
+        unit_gauge.transferFrom(accounts[0], accounts[2], balance, {"from": accounts[1]})
+
+
+def test_infinite_approval(accounts, unit_gauge):
+    unit_gauge.approve(accounts[1], 2 ** 256 - 1, {"from": accounts[0]})
+    unit_gauge.transferFrom(accounts[0], accounts[2], 10000, {"from": accounts[1]})
+
+    assert unit_gauge.allowance(accounts[0], accounts[1]) == 2 ** 256 - 1
+
+
+def test_revoked_approval(accounts, unit_gauge):
+    balance = unit_gauge.balanceOf(accounts[0])
+
+    unit_gauge.approve(accounts[1], balance, {"from": accounts[0]})
+    unit_gauge.approve(accounts[1], 0, {"from": accounts[0]})
+
+    with brownie.reverts():
+        unit_gauge.transferFrom(accounts[0], accounts[2], balance, {"from": accounts[1]})
+
+
+def test_transfer_to_self(accounts, unit_gauge):
+    sender_balance = unit_gauge.balanceOf(accounts[0])
+    amount = sender_balance // 4
+
+    unit_gauge.approve(accounts[0], sender_balance, {"from": accounts[0]})
+    unit_gauge.transferFrom(accounts[0], accounts[0], amount, {"from": accounts[0]})
+
+    assert unit_gauge.balanceOf(accounts[0]) == sender_balance
+    assert unit_gauge.allowance(accounts[0], accounts[0]) == sender_balance - amount
+
+
+def test_transfer_to_self_no_approval(accounts, unit_gauge):
+    amount = unit_gauge.balanceOf(accounts[0])
+
+    with brownie.reverts():
+        unit_gauge.transferFrom(accounts[0], accounts[0], amount, {"from": accounts[0]})
+
+
+def test_transfer_event_fires(accounts, unit_gauge):
+    amount = unit_gauge.balanceOf(accounts[0])
+
+    unit_gauge.approve(accounts[1], amount, {"from": accounts[0]})
+    tx = unit_gauge.transferFrom(accounts[0], accounts[2], amount, {"from": accounts[1]})
+
+    assert tx.events["Transfer"].values() == [accounts[0], accounts[2], amount]

--- a/tests/unitary/LiquidityGaugeWrapperUnit/test_vault.py
+++ b/tests/unitary/LiquidityGaugeWrapperUnit/test_vault.py
@@ -1,0 +1,174 @@
+import brownie
+import pytest
+from brownie import chain
+
+MONTH = 86400 * 30
+
+
+@pytest.fixture(scope="module", autouse=True)
+def deposit_setup(
+    accounts, gauge_controller, minter, liquidity_gauge, unit_gauge, token, mock_lp_token, vault,
+):
+    token.set_minter(minter, {"from": accounts[0]})
+
+    gauge_controller.add_type(b"Liquidity", 10 ** 10, {"from": accounts[0]})
+    gauge_controller.add_gauge(liquidity_gauge, 0, 10 ** 18, {"from": accounts[0]})
+    chain.sleep(86400 * 7)
+
+    # transfer tokens
+    for acct in accounts[1:4]:
+        mock_lp_token.transfer(acct, 1e18, {"from": accounts[0]})
+
+    # approve gauge and wrapper
+    for acct in accounts[:4]:
+        mock_lp_token.approve(unit_gauge, 2** 256 - 1, {"from": acct})
+        unit_gauge.approve(vault, 2 ** 256 - 1, {'from': acct})
+
+
+def test_deposit(alice, unit_gauge, vault):
+    unit_gauge.deposit(100000, {'from': alice})
+    vault.deposit(25000, {'from': alice})
+    assert unit_gauge.balanceOf(alice) == 75000
+    assert unit_gauge.depositedBalanceOf(alice) == 25000
+    assert unit_gauge.balanceOf(vault) == 25000
+    assert unit_gauge.totalSupply() == 100000
+
+
+def test_deposit_multiple(alice, unit_gauge, vault):
+    unit_gauge.deposit(100000, {'from': alice})
+    vault.deposit(10000, {'from': alice})
+    unit_gauge.deposit(100000, {"from": alice})
+    vault.deposit(30000, {'from': alice})
+    assert unit_gauge.balanceOf(alice) == 160000
+    assert unit_gauge.depositedBalanceOf(alice) == 40000
+    assert unit_gauge.balanceOf(vault) == 40000
+    assert unit_gauge.totalSupply() == 200000
+
+
+def test_withdraw_partial(alice, unit_gauge, vault):
+    unit_gauge.deposit(100000, {'from': alice})
+    vault.deposit(25000, {'from': alice})
+    vault.withdraw(15000, {'from': alice})
+
+    assert unit_gauge.balanceOf(alice) == 90000
+    assert unit_gauge.depositedBalanceOf(alice) == 10000
+    assert unit_gauge.balanceOf(vault) == 10000
+    assert unit_gauge.totalSupply() == 100000
+
+
+def test_withdraw_full(alice, unit_gauge, vault):
+    unit_gauge.deposit(100000, {'from': alice})
+    vault.deposit(25000, {'from': alice})
+    vault.withdraw(25000, {'from': alice})
+
+    assert unit_gauge.balanceOf(alice) == 100000
+    assert unit_gauge.depositedBalanceOf(alice) == 0
+    assert unit_gauge.balanceOf(vault) == 0
+    assert unit_gauge.totalSupply() == 100000
+
+
+def test_withdraw_multiple(alice, unit_gauge, vault):
+    unit_gauge.deposit(100000, {'from': alice})
+    vault.deposit(100000, {'from': alice})
+    vault.withdraw(15000, {'from': alice})
+    vault.withdraw(55000, {'from': alice})
+
+    assert unit_gauge.balanceOf(alice) == 70000
+    assert unit_gauge.depositedBalanceOf(alice) == 30000
+    assert unit_gauge.balanceOf(vault) == 30000
+    assert unit_gauge.totalSupply() == 100000
+
+
+def test_claim_in_vault(bob, liquidity_gauge, unit_gauge, vault, token):
+    unit_gauge.deposit(100000, {'from': bob})
+    vault.deposit(100000, {'from': bob})
+
+    chain.sleep(MONTH)
+    unit_gauge.claim_tokens({"from": bob})
+    expected = liquidity_gauge.integrate_fraction(unit_gauge)
+
+    assert expected > 0
+    assert token.balanceOf(bob) == expected
+
+
+def test_claim_partially_in_vault(bob, liquidity_gauge, unit_gauge, vault, token):
+    unit_gauge.deposit(100000, {'from': bob})
+    vault.deposit(40000, {'from': bob})
+
+    chain.sleep(MONTH)
+    unit_gauge.claim_tokens({"from": bob})
+    expected = liquidity_gauge.integrate_fraction(unit_gauge)
+
+    assert expected > 0
+    assert token.balanceOf(bob) == expected
+
+
+def test_claim_multiple_depositors(bob, charlie, liquidity_gauge, unit_gauge, vault, token):
+    unit_gauge.deposit(100000, {'from': bob})
+    unit_gauge.deposit(100000, {'from': charlie})
+    vault.deposit(50000, {'from': bob})
+
+    chain.sleep(MONTH)
+    vault.withdraw(50000, {'from': bob})
+    unit_gauge.withdraw(100000, {'from': bob})
+    vault.deposit(50000, {'from': charlie})
+
+    chain.sleep(MONTH)
+
+    unit_gauge.claim_tokens({"from": bob})
+    unit_gauge.claim_tokens({"from": charlie})
+    expected = liquidity_gauge.integrate_fraction(unit_gauge)
+
+    assert expected > 0
+
+    balance_bob = token.balanceOf(bob)
+    balance_charlie = token.balanceOf(charlie)
+    assert (balance_bob * 3 / balance_charlie) == pytest.approx(1)
+
+
+def test_vault_cannot_claim(bob, liquidity_gauge, unit_gauge, vault, token):
+    unit_gauge.deposit(100000, {'from': bob})
+
+    # deposit into vault, and also directly transfer tokens into the vault
+    # neither of these scenarios should allow the vault to claim!
+    vault.deposit(50000, {'from': bob})
+    unit_gauge.transfer(vault, 50000, {'from': bob})
+
+    chain.sleep(MONTH)
+    unit_gauge.claim_tokens(vault, {"from": bob})
+    expected = liquidity_gauge.integrate_fraction(unit_gauge)
+
+    assert expected > 0
+    assert token.balanceOf(vault) == 0
+
+
+def test_liquidate(bob, charlie, unit_gauge, vault):
+    unit_gauge.deposit(100000, {'from': bob})
+    vault.deposit(50000, {'from': bob})
+
+    vault.liquidate(bob, 30000, {'from': charlie})
+
+    assert unit_gauge.balanceOf(bob) == 70000
+    assert unit_gauge.depositedBalanceOf(bob) == 0
+    assert unit_gauge.balanceOf(charlie) == 30000
+    assert unit_gauge.depositedBalanceOf(charlie) == 0
+
+    assert unit_gauge.balanceOf(vault) == 0
+    assert unit_gauge.totalSupply() == 100000
+
+
+def test_liquidator_has_balances(bob, charlie, unit_gauge, vault):
+    unit_gauge.deposit(100000, {'from': bob})
+    unit_gauge.deposit(100000, {'from': charlie})
+    vault.deposit(50000, {'from': bob})
+    vault.deposit(50000, {'from': charlie})
+
+    vault.liquidate(bob, 30000, {'from': charlie})
+
+    assert unit_gauge.balanceOf(bob) == 70000
+    assert unit_gauge.depositedBalanceOf(bob) == 0
+    assert unit_gauge.balanceOf(charlie) == 80000
+    assert unit_gauge.depositedBalanceOf(charlie) == 50000
+
+    assert unit_gauge.balanceOf(vault) == 50000
+    assert unit_gauge.totalSupply() == 200000

--- a/tests/unitary/LiquidityGaugeWrapperUnit/test_vault.py
+++ b/tests/unitary/LiquidityGaugeWrapperUnit/test_vault.py
@@ -1,4 +1,3 @@
-import brownie
 import pytest
 from brownie import chain
 
@@ -21,13 +20,13 @@ def deposit_setup(
 
     # approve gauge and wrapper
     for acct in accounts[:4]:
-        mock_lp_token.approve(unit_gauge, 2** 256 - 1, {"from": acct})
-        unit_gauge.approve(vault, 2 ** 256 - 1, {'from': acct})
+        mock_lp_token.approve(unit_gauge, 2 ** 256 - 1, {"from": acct})
+        unit_gauge.approve(vault, 2 ** 256 - 1, {"from": acct})
 
 
 def test_deposit(alice, unit_gauge, vault):
-    unit_gauge.deposit(100000, {'from': alice})
-    vault.deposit(25000, {'from': alice})
+    unit_gauge.deposit(100000, {"from": alice})
+    vault.deposit(25000, {"from": alice})
     assert unit_gauge.balanceOf(alice) == 75000
     assert unit_gauge.depositedBalanceOf(alice) == 25000
     assert unit_gauge.balanceOf(vault) == 25000
@@ -35,10 +34,10 @@ def test_deposit(alice, unit_gauge, vault):
 
 
 def test_deposit_multiple(alice, unit_gauge, vault):
-    unit_gauge.deposit(100000, {'from': alice})
-    vault.deposit(10000, {'from': alice})
     unit_gauge.deposit(100000, {"from": alice})
-    vault.deposit(30000, {'from': alice})
+    vault.deposit(10000, {"from": alice})
+    unit_gauge.deposit(100000, {"from": alice})
+    vault.deposit(30000, {"from": alice})
     assert unit_gauge.balanceOf(alice) == 160000
     assert unit_gauge.depositedBalanceOf(alice) == 40000
     assert unit_gauge.balanceOf(vault) == 40000
@@ -46,9 +45,9 @@ def test_deposit_multiple(alice, unit_gauge, vault):
 
 
 def test_withdraw_partial(alice, unit_gauge, vault):
-    unit_gauge.deposit(100000, {'from': alice})
-    vault.deposit(25000, {'from': alice})
-    vault.withdraw(15000, {'from': alice})
+    unit_gauge.deposit(100000, {"from": alice})
+    vault.deposit(25000, {"from": alice})
+    vault.withdraw(15000, {"from": alice})
 
     assert unit_gauge.balanceOf(alice) == 90000
     assert unit_gauge.depositedBalanceOf(alice) == 10000
@@ -57,9 +56,9 @@ def test_withdraw_partial(alice, unit_gauge, vault):
 
 
 def test_withdraw_full(alice, unit_gauge, vault):
-    unit_gauge.deposit(100000, {'from': alice})
-    vault.deposit(25000, {'from': alice})
-    vault.withdraw(25000, {'from': alice})
+    unit_gauge.deposit(100000, {"from": alice})
+    vault.deposit(25000, {"from": alice})
+    vault.withdraw(25000, {"from": alice})
 
     assert unit_gauge.balanceOf(alice) == 100000
     assert unit_gauge.depositedBalanceOf(alice) == 0
@@ -68,10 +67,10 @@ def test_withdraw_full(alice, unit_gauge, vault):
 
 
 def test_withdraw_multiple(alice, unit_gauge, vault):
-    unit_gauge.deposit(100000, {'from': alice})
-    vault.deposit(100000, {'from': alice})
-    vault.withdraw(15000, {'from': alice})
-    vault.withdraw(55000, {'from': alice})
+    unit_gauge.deposit(100000, {"from": alice})
+    vault.deposit(100000, {"from": alice})
+    vault.withdraw(15000, {"from": alice})
+    vault.withdraw(55000, {"from": alice})
 
     assert unit_gauge.balanceOf(alice) == 70000
     assert unit_gauge.depositedBalanceOf(alice) == 30000
@@ -80,8 +79,8 @@ def test_withdraw_multiple(alice, unit_gauge, vault):
 
 
 def test_claim_in_vault(bob, liquidity_gauge, unit_gauge, vault, token):
-    unit_gauge.deposit(100000, {'from': bob})
-    vault.deposit(100000, {'from': bob})
+    unit_gauge.deposit(100000, {"from": bob})
+    vault.deposit(100000, {"from": bob})
 
     chain.sleep(MONTH)
     unit_gauge.claim_tokens({"from": bob})
@@ -92,8 +91,8 @@ def test_claim_in_vault(bob, liquidity_gauge, unit_gauge, vault, token):
 
 
 def test_claim_partially_in_vault(bob, liquidity_gauge, unit_gauge, vault, token):
-    unit_gauge.deposit(100000, {'from': bob})
-    vault.deposit(40000, {'from': bob})
+    unit_gauge.deposit(100000, {"from": bob})
+    vault.deposit(40000, {"from": bob})
 
     chain.sleep(MONTH)
     unit_gauge.claim_tokens({"from": bob})
@@ -104,14 +103,14 @@ def test_claim_partially_in_vault(bob, liquidity_gauge, unit_gauge, vault, token
 
 
 def test_claim_multiple_depositors(bob, charlie, liquidity_gauge, unit_gauge, vault, token):
-    unit_gauge.deposit(100000, {'from': bob})
-    unit_gauge.deposit(100000, {'from': charlie})
-    vault.deposit(50000, {'from': bob})
+    unit_gauge.deposit(100000, {"from": bob})
+    unit_gauge.deposit(100000, {"from": charlie})
+    vault.deposit(50000, {"from": bob})
 
     chain.sleep(MONTH)
-    vault.withdraw(50000, {'from': bob})
-    unit_gauge.withdraw(100000, {'from': bob})
-    vault.deposit(50000, {'from': charlie})
+    vault.withdraw(50000, {"from": bob})
+    unit_gauge.withdraw(100000, {"from": bob})
+    vault.deposit(50000, {"from": charlie})
 
     chain.sleep(MONTH)
 
@@ -127,12 +126,12 @@ def test_claim_multiple_depositors(bob, charlie, liquidity_gauge, unit_gauge, va
 
 
 def test_vault_cannot_claim(bob, liquidity_gauge, unit_gauge, vault, token):
-    unit_gauge.deposit(100000, {'from': bob})
+    unit_gauge.deposit(100000, {"from": bob})
 
     # deposit into vault, and also directly transfer tokens into the vault
     # neither of these scenarios should allow the vault to claim!
-    vault.deposit(50000, {'from': bob})
-    unit_gauge.transfer(vault, 50000, {'from': bob})
+    vault.deposit(50000, {"from": bob})
+    unit_gauge.transfer(vault, 50000, {"from": bob})
 
     chain.sleep(MONTH)
     unit_gauge.claim_tokens(vault, {"from": bob})
@@ -143,10 +142,10 @@ def test_vault_cannot_claim(bob, liquidity_gauge, unit_gauge, vault, token):
 
 
 def test_liquidate(bob, charlie, unit_gauge, vault):
-    unit_gauge.deposit(100000, {'from': bob})
-    vault.deposit(50000, {'from': bob})
+    unit_gauge.deposit(100000, {"from": bob})
+    vault.deposit(50000, {"from": bob})
 
-    vault.liquidate(bob, 30000, {'from': charlie})
+    vault.liquidate(bob, 30000, {"from": charlie})
 
     assert unit_gauge.balanceOf(bob) == 70000
     assert unit_gauge.depositedBalanceOf(bob) == 0
@@ -158,12 +157,12 @@ def test_liquidate(bob, charlie, unit_gauge, vault):
 
 
 def test_liquidator_has_balances(bob, charlie, unit_gauge, vault):
-    unit_gauge.deposit(100000, {'from': bob})
-    unit_gauge.deposit(100000, {'from': charlie})
-    vault.deposit(50000, {'from': bob})
-    vault.deposit(50000, {'from': charlie})
+    unit_gauge.deposit(100000, {"from": bob})
+    unit_gauge.deposit(100000, {"from": charlie})
+    vault.deposit(50000, {"from": bob})
+    vault.deposit(50000, {"from": charlie})
 
-    vault.liquidate(bob, 30000, {'from': charlie})
+    vault.liquidate(bob, 30000, {"from": charlie})
 
     assert unit_gauge.balanceOf(bob) == 70000
     assert unit_gauge.depositedBalanceOf(bob) == 0


### PR DESCRIPTION
### What I did
Add a liquidity gauge wrapper that integrates with the unit.xyz [`Vault`](https://github.com/unitprotocol/core/blob/e5fb43009e23c39906a6366abc75c85ddd1b6ee5/contracts/Vault.sol) to allow users to claim CRV on their deposited collateral.
