### PR TITLE
Rewards-only gauge

### DIFF
--- a/contracts/gauges/RewardsOnlyGauge.vy
+++ b/contracts/gauges/RewardsOnlyGauge.vy
@@ -1,0 +1,513 @@
+# @version 0.2.12
+"""
+@title Rewards-Only Gauge
+@author Curve Finance
+@license MIT
+@notice Distribution of third-party rewards without CRV
+"""
+
+from vyper.interfaces import ERC20
+
+implements: ERC20
+
+
+interface ERC20Extended:
+    def symbol() -> String[26]: view
+
+
+event Deposit:
+    provider: indexed(address)
+    value: uint256
+
+event Withdraw:
+    provider: indexed(address)
+    value: uint256
+
+event CommitOwnership:
+    admin: address
+
+event ApplyOwnership:
+    admin: address
+
+event Transfer:
+    _from: indexed(address)
+    _to: indexed(address)
+    _value: uint256
+
+event Approval:
+    _owner: indexed(address)
+    _spender: indexed(address)
+    _value: uint256
+
+
+MAX_REWARDS: constant(uint256) = 8
+
+lp_token: public(address)
+
+balanceOf: public(HashMap[address, uint256])
+totalSupply: public(uint256)
+allowance: public(HashMap[address, HashMap[address, uint256]])
+
+name: public(String[64])
+symbol: public(String[32])
+
+# caller -> recipient -> can deposit?
+approved_to_deposit: public(HashMap[address, HashMap[address, bool]])
+
+# For tracking external rewards
+reward_contract: public(address)
+reward_tokens: public(address[MAX_REWARDS])
+reward_balances: public(HashMap[address, uint256])
+
+# deposit / withdraw / claim
+reward_sigs: bytes32
+
+# reward token -> integral
+reward_integral: public(HashMap[address, uint256])
+
+# reward token -> claiming address -> integral
+reward_integral_for: public(HashMap[address, HashMap[address, uint256]])
+
+admin: public(address)
+future_admin: public(address)  # Can and will be a smart contract
+is_killed: public(bool)
+
+
+@external
+def __init__(_lp_token: address, _admin: address):
+    """
+    @notice Contract constructor
+    @param _lp_token Liquidity Pool contract address
+    @param _admin Admin who can kill the gauge
+    """
+
+    symbol: String[26] = ERC20Extended(_lp_token).symbol()
+    self.name = concat("Curve.fi ", symbol, " RewardGauge Deposit")
+    self.symbol = concat(symbol, "-gauge")
+
+    self.lp_token = _lp_token
+    self.admin = _admin
+
+
+@view
+@external
+def decimals() -> uint256:
+    """
+    @notice Get the number of decimals for this token
+    @dev Implemented as a view method to reduce gas costs
+    @return uint256 decimal places
+    """
+    return 18
+
+
+@internal
+def _checkpoint_rewards(_addr: address, _total_supply: uint256):
+    """
+    @notice Claim pending rewards and checkpoint rewards for a user
+    """
+    if _total_supply == 0:
+        return
+
+    # claim from reward contract
+    if self.reward_contract != ZERO_ADDRESS:
+        raw_call(self.reward_contract, slice(self.reward_sigs, 8, 4))  # dev: bad claim sig
+
+    user_balance: uint256 = self.balanceOf[_addr]
+    for i in range(MAX_REWARDS):
+        token: address = self.reward_tokens[i]
+        if token == ZERO_ADDRESS:
+            break
+        token_balance: uint256 = ERC20(token).balanceOf(self)
+        dI: uint256 = 10**18 * (token_balance - self.reward_balances[token]) / _total_supply
+        self.reward_balances[token] = token_balance
+        if _addr == ZERO_ADDRESS:
+            if dI != 0:
+                self.reward_integral[token] += dI
+            continue
+
+        integral: uint256 = self.reward_integral[token] + dI
+        if dI != 0:
+            self.reward_integral[token] = integral
+
+        integral_for: uint256 = self.reward_integral_for[token][_addr]
+        if integral_for < integral:
+            claimable: uint256 = user_balance * (integral - integral_for) / 10**18
+            self.reward_integral_for[token][_addr] = integral
+            if claimable != 0:
+                response: Bytes[32] = raw_call(
+                    token,
+                    concat(
+                        method_id("transfer(address,uint256)"),
+                        convert(_addr, bytes32),
+                        convert(claimable, bytes32),
+                    ),
+                    max_outsize=32,
+                )
+                if len(response) != 0:
+                    assert convert(response, bool)
+                self.reward_balances[token] -= claimable
+
+
+@external
+@nonreentrant('lock')
+def claimable_reward(_addr: address, _token: address) -> uint256:
+    """
+    @notice Get the number of claimable reward tokens for a user
+    @dev This function should be manually changed to "view" in the ABI
+         Calling it via a transaction will claim available reward tokens
+    @param _addr Account to get reward amount for
+    @param _token Token to get reward amount for
+    @return uint256 Claimable reward token amount
+    """
+    claimable: uint256 = ERC20(_token).balanceOf(_addr)
+    self._checkpoint_rewards(_addr, self.totalSupply)
+    claimable = ERC20(_token).balanceOf(_addr) - claimable
+
+    integral: uint256 = self.reward_integral[_token]
+    integral_for: uint256 = self.reward_integral_for[_token][_addr]
+
+    if integral_for < integral:
+        claimable += self.balanceOf[_addr] * (integral - integral_for) / 10**18
+
+    return claimable
+
+
+@external
+@nonreentrant('lock')
+def claim_rewards(_addr: address = msg.sender):
+    """
+    @notice Claim available reward tokens for `_addr`
+    @param _addr Address to claim for
+    """
+    self._checkpoint_rewards(_addr, self.totalSupply)
+
+
+@external
+@nonreentrant('lock')
+def claim_historic_rewards(_reward_tokens: address[MAX_REWARDS], _addr: address = msg.sender):
+    """
+    @notice Claim reward tokens available from a previously-set staking contract
+    @param _reward_tokens Array of reward token addresses to claim
+    @param _addr Address to claim for
+    """
+    for token in _reward_tokens:
+        if token == ZERO_ADDRESS:
+            break
+        integral: uint256 = self.reward_integral[token]
+        integral_for: uint256 = self.reward_integral_for[token][_addr]
+
+        if integral_for < integral:
+            claimable: uint256 = self.balanceOf[_addr] * (integral - integral_for) / 10**18
+            self.reward_integral_for[token][_addr] = integral
+            response: Bytes[32] = raw_call(
+                token,
+                concat(
+                    method_id("transfer(address,uint256)"),
+                    convert(_addr, bytes32),
+                    convert(claimable, bytes32),
+                ),
+                max_outsize=32,
+            )
+            if len(response) != 0:
+                assert convert(response, bool)
+            self.reward_balances[token] -= claimable
+
+
+@external
+def set_approve_deposit(addr: address, can_deposit: bool):
+    """
+    @notice Set whether `addr` can deposit tokens for `msg.sender`
+    @param addr Address to set approval on
+    @param can_deposit bool - can this account deposit for `msg.sender`?
+    """
+    self.approved_to_deposit[addr][msg.sender] = can_deposit
+
+
+@external
+@nonreentrant('lock')
+def deposit(_value: uint256, _addr: address = msg.sender):
+    """
+    @notice Deposit `_value` LP tokens
+    @dev Depositting also claims pending reward tokens
+    @param _value Number of tokens to deposit
+    @param _addr Address to deposit for
+    """
+    if _addr != msg.sender:
+        assert self.approved_to_deposit[msg.sender][_addr], "Not approved"
+
+
+    if _value != 0:
+        reward_contract: address = self.reward_contract
+        total_supply: uint256 = self.totalSupply
+
+        self._checkpoint_rewards(_addr, total_supply)
+
+        total_supply += _value
+        new_balance: uint256 = self.balanceOf[_addr] + _value
+        self.balanceOf[_addr] = new_balance
+        self.totalSupply = total_supply
+
+        ERC20(self.lp_token).transferFrom(msg.sender, self, _value)
+        if reward_contract != ZERO_ADDRESS:
+            deposit_sig: Bytes[4] = slice(self.reward_sigs, 0, 4)
+            if convert(deposit_sig, uint256) != 0:
+                raw_call(
+                    reward_contract,
+                    concat(deposit_sig, convert(_value, bytes32))
+                )
+
+    log Deposit(_addr, _value)
+    log Transfer(ZERO_ADDRESS, _addr, _value)
+
+
+@external
+@nonreentrant('lock')
+def withdraw(_value: uint256):
+    """
+    @notice Withdraw `_value` LP tokens
+    @dev Withdrawing also claims pending reward tokens
+    @param _value Number of tokens to withdraw
+    """
+
+    if _value != 0:
+        reward_contract: address = self.reward_contract
+        total_supply: uint256 = self.totalSupply
+
+        self._checkpoint_rewards(msg.sender, total_supply)
+
+        total_supply -= _value
+        new_balance: uint256 = self.balanceOf[msg.sender] - _value
+        self.balanceOf[msg.sender] = new_balance
+        self.totalSupply = total_supply
+
+        if reward_contract != ZERO_ADDRESS:
+            withdraw_sig: Bytes[4] = slice(self.reward_sigs, 4, 4)
+            if convert(withdraw_sig, uint256) != 0:
+                raw_call(
+                    reward_contract,
+                    concat(withdraw_sig, convert(_value, bytes32))
+                )
+        ERC20(self.lp_token).transfer(msg.sender, _value)
+
+    log Withdraw(msg.sender, _value)
+    log Transfer(msg.sender, ZERO_ADDRESS, _value)
+
+
+@internal
+def _transfer(_from: address, _to: address, _value: uint256):
+    reward_contract: address = self.reward_contract
+
+    if _value != 0:
+        total_supply: uint256 = self.totalSupply
+        self._checkpoint_rewards(_from, total_supply)
+        new_balance: uint256 = self.balanceOf[_from] - _value
+        self.balanceOf[_from] = new_balance
+
+        self._checkpoint_rewards(_to, total_supply)
+        new_balance = self.balanceOf[_to] + _value
+        self.balanceOf[_to] = new_balance
+
+    log Transfer(_from, _to, _value)
+
+
+@external
+@nonreentrant('lock')
+def transfer(_to : address, _value : uint256) -> bool:
+    """
+    @notice Transfer token for a specified address
+    @dev Transferring claims pending reward tokens for the sender and receiver
+    @param _to The address to transfer to.
+    @param _value The amount to be transferred.
+    """
+    self._transfer(msg.sender, _to, _value)
+
+    return True
+
+
+@external
+@nonreentrant('lock')
+def transferFrom(_from : address, _to : address, _value : uint256) -> bool:
+    """
+     @notice Transfer tokens from one address to another.
+     @dev Transferring claims pending reward tokens for the sender and receiver
+     @param _from address The address which you want to send tokens from
+     @param _to address The address which you want to transfer to
+     @param _value uint256 the amount of tokens to be transferred
+    """
+    _allowance: uint256 = self.allowance[_from][msg.sender]
+    if _allowance != MAX_UINT256:
+        self.allowance[_from][msg.sender] = _allowance - _value
+
+    self._transfer(_from, _to, _value)
+
+    return True
+
+
+@external
+def approve(_spender : address, _value : uint256) -> bool:
+    """
+    @notice Approve the passed address to transfer the specified amount of
+            tokens on behalf of msg.sender
+    @dev Beware that changing an allowance via this method brings the risk
+         that someone may use both the old and new allowance by unfortunate
+         transaction ordering. This may be mitigated with the use of
+         {incraseAllowance} and {decreaseAllowance}.
+         https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+    @param _spender The address which will transfer the funds
+    @param _value The amount of tokens that may be transferred
+    @return bool success
+    """
+    self.allowance[msg.sender][_spender] = _value
+    log Approval(msg.sender, _spender, _value)
+
+    return True
+
+
+@external
+def increaseAllowance(_spender: address, _added_value: uint256) -> bool:
+    """
+    @notice Increase the allowance granted to `_spender` by the caller
+    @dev This is alternative to {approve} that can be used as a mitigation for
+         the potential race condition
+    @param _spender The address which will transfer the funds
+    @param _added_value The amount of to increase the allowance
+    @return bool success
+    """
+    allowance: uint256 = self.allowance[msg.sender][_spender] + _added_value
+    self.allowance[msg.sender][_spender] = allowance
+
+    log Approval(msg.sender, _spender, allowance)
+
+    return True
+
+
+@external
+def decreaseAllowance(_spender: address, _subtracted_value: uint256) -> bool:
+    """
+    @notice Decrease the allowance granted to `_spender` by the caller
+    @dev This is alternative to {approve} that can be used as a mitigation for
+         the potential race condition
+    @param _spender The address which will transfer the funds
+    @param _subtracted_value The amount of to decrease the allowance
+    @return bool success
+    """
+    allowance: uint256 = self.allowance[msg.sender][_spender] - _subtracted_value
+    self.allowance[msg.sender][_spender] = allowance
+
+    log Approval(msg.sender, _spender, allowance)
+
+    return True
+
+
+@external
+@nonreentrant('lock')
+def set_rewards(_reward_contract: address, _sigs: bytes32, _reward_tokens: address[MAX_REWARDS]):
+    """
+    @notice Set the active reward contract
+    @dev A reward contract cannot be set while this contract has no deposits
+    @param _reward_contract Reward contract address. Set to ZERO_ADDRESS to
+                            disable staking.
+    @param _sigs Four byte selectors for staking, withdrawing and claiming,
+                 right padded with zero bytes. If the reward contract can
+                 be claimed from but does not require staking, the staking
+                 and withdraw selectors should be set to 0x00
+    @param _reward_tokens List of claimable tokens for this reward contract
+    """
+    assert msg.sender == self.admin
+
+    lp_token: address = self.lp_token
+    current_reward_contract: address = self.reward_contract
+    total_supply: uint256 = self.totalSupply
+    self._checkpoint_rewards(ZERO_ADDRESS, total_supply)
+    if current_reward_contract != ZERO_ADDRESS:
+        withdraw_sig: Bytes[4] = slice(self.reward_sigs, 4, 4)
+        if convert(withdraw_sig, uint256) != 0:
+            if total_supply != 0:
+                raw_call(
+                    current_reward_contract,
+                    concat(withdraw_sig, convert(total_supply, bytes32))
+                )
+            ERC20(lp_token).approve(current_reward_contract, 0)
+
+    if _reward_contract != ZERO_ADDRESS:
+        assert _reward_contract.is_contract  # dev: not a contract
+        sigs: bytes32 = _sigs
+        deposit_sig: Bytes[4] = slice(sigs, 0, 4)
+        withdraw_sig: Bytes[4] = slice(sigs, 4, 4)
+
+        if convert(deposit_sig, uint256) != 0:
+            # need a non-zero total supply to verify the sigs
+            assert total_supply != 0  # dev: zero total supply
+            ERC20(lp_token).approve(_reward_contract, MAX_UINT256)
+
+            # it would be Very Bad if we get the signatures wrong here, so
+            # we do a test deposit and withdrawal prior to setting them
+            raw_call(
+                _reward_contract,
+                concat(deposit_sig, convert(total_supply, bytes32))
+            )  # dev: failed deposit
+            assert ERC20(lp_token).balanceOf(self) == 0
+            raw_call(
+                _reward_contract,
+                concat(withdraw_sig, convert(total_supply, bytes32))
+            )  # dev: failed withdraw
+            assert ERC20(lp_token).balanceOf(self) == total_supply
+
+            # deposit and withdraw are good, time to make the actual deposit
+            raw_call(
+                _reward_contract,
+                concat(deposit_sig, convert(total_supply, bytes32))
+            )
+        else:
+            assert convert(withdraw_sig, uint256) == 0  # dev: withdraw without deposit
+
+    self.reward_contract = _reward_contract
+    self.reward_sigs = _sigs
+    for i in range(MAX_REWARDS):
+        if _reward_tokens[i] != ZERO_ADDRESS:
+            self.reward_tokens[i] = _reward_tokens[i]
+        elif self.reward_tokens[i] != ZERO_ADDRESS:
+            self.reward_tokens[i] = ZERO_ADDRESS
+        else:
+            assert i != 0  # dev: no reward token
+            break
+
+    if _reward_contract != ZERO_ADDRESS:
+        # do an initial checkpoint to verify that claims are working
+        self._checkpoint_rewards(ZERO_ADDRESS, total_supply)
+
+
+@external
+def set_killed(_is_killed: bool):
+    """
+    @notice Set the killed status for this contract
+    @dev When killed, the gauge always yields a rate of 0 and so cannot mint CRV
+    @param _is_killed Killed status to set
+    """
+    assert msg.sender == self.admin
+
+    self.is_killed = _is_killed
+
+
+@external
+def commit_transfer_ownership(addr: address):
+    """
+    @notice Transfer ownership of GaugeController to `addr`
+    @param addr Address to have ownership transferred to
+    """
+    assert msg.sender == self.admin  # dev: admin only
+
+    self.future_admin = addr
+    log CommitOwnership(addr)
+
+
+@external
+def accept_transfer_ownership():
+    """
+    @notice Accept a pending ownership transfer
+    """
+    _admin: address = self.future_admin
+    assert msg.sender == _admin  # dev: future admin only
+
+    self.admin = _admin
+    log ApplyOwnership(_admin)

--- a/contracts/gauges/RewardsOnlyGauge.vy
+++ b/contracts/gauges/RewardsOnlyGauge.vy
@@ -70,7 +70,6 @@ reward_integral_for: public(HashMap[address, HashMap[address, uint256]])
 
 admin: public(address)
 future_admin: public(address)  # Can and will be a smart contract
-is_killed: public(bool)
 
 
 @external
@@ -475,18 +474,6 @@ def set_rewards(_reward_contract: address, _sigs: bytes32, _reward_tokens: addre
     if _reward_contract != ZERO_ADDRESS:
         # do an initial checkpoint to verify that claims are working
         self._checkpoint_rewards(ZERO_ADDRESS, total_supply)
-
-
-@external
-def set_killed(_is_killed: bool):
-    """
-    @notice Set the killed status for this contract
-    @dev When killed, the gauge always yields a rate of 0 and so cannot mint CRV
-    @param _is_killed Killed status to set
-    """
-    assert msg.sender == self.admin
-
-    self.is_killed = _is_killed
 
 
 @external

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,6 +133,11 @@ def gauge_v2(LiquidityGaugeV2, alice, mock_lp_token, minter):
 
 
 @pytest.fixture(scope="module")
+def rewards_only_gauge(RewardsOnlyGauge, alice, mock_lp_token):
+    yield RewardsOnlyGauge.deploy(mock_lp_token, alice, {"from": alice})
+
+
+@pytest.fixture(scope="module")
 def gauge_wrapper(LiquidityGaugeWrapper, accounts, liquidity_gauge):
     yield LiquidityGaugeWrapper.deploy(
         "Tokenized Gauge", "TG", liquidity_gauge, accounts[0], {"from": accounts[0]}

--- a/tests/unitary/RewardsOnlyGauge/test_approve.py
+++ b/tests/unitary/RewardsOnlyGauge/test_approve.py
@@ -1,0 +1,65 @@
+import pytest
+
+
+@pytest.mark.parametrize("idx", range(5))
+def test_initial_approval_is_zero(rewards_only_gauge, accounts, idx):
+    assert rewards_only_gauge.allowance(accounts[0], accounts[idx]) == 0
+
+
+def test_approve(rewards_only_gauge, accounts):
+    rewards_only_gauge.approve(accounts[1], 10 ** 19, {"from": accounts[0]})
+
+    assert rewards_only_gauge.allowance(accounts[0], accounts[1]) == 10 ** 19
+
+
+def test_modify_approve(rewards_only_gauge, accounts):
+    rewards_only_gauge.approve(accounts[1], 10 ** 19, {"from": accounts[0]})
+    rewards_only_gauge.approve(accounts[1], 12345678, {"from": accounts[0]})
+
+    assert rewards_only_gauge.allowance(accounts[0], accounts[1]) == 12345678
+
+
+def test_revoke_approve(rewards_only_gauge, accounts):
+    rewards_only_gauge.approve(accounts[1], 10 ** 19, {"from": accounts[0]})
+    rewards_only_gauge.approve(accounts[1], 0, {"from": accounts[0]})
+
+    assert rewards_only_gauge.allowance(accounts[0], accounts[1]) == 0
+
+
+def test_approve_self(rewards_only_gauge, accounts):
+    rewards_only_gauge.approve(accounts[0], 10 ** 19, {"from": accounts[0]})
+
+    assert rewards_only_gauge.allowance(accounts[0], accounts[0]) == 10 ** 19
+
+
+def test_only_affects_target(rewards_only_gauge, accounts):
+    rewards_only_gauge.approve(accounts[1], 10 ** 19, {"from": accounts[0]})
+
+    assert rewards_only_gauge.allowance(accounts[1], accounts[0]) == 0
+
+
+def test_returns_true(rewards_only_gauge, accounts):
+    tx = rewards_only_gauge.approve(accounts[1], 10 ** 19, {"from": accounts[0]})
+
+    assert tx.return_value is True
+
+
+def test_approval_event_fires(accounts, rewards_only_gauge):
+    tx = rewards_only_gauge.approve(accounts[1], 10 ** 19, {"from": accounts[0]})
+
+    assert len(tx.events) == 1
+    assert tx.events["Approval"].values() == [accounts[0], accounts[1], 10 ** 19]
+
+
+def test_increase_allowance(accounts, rewards_only_gauge):
+    rewards_only_gauge.approve(accounts[1], 100, {"from": accounts[0]})
+    rewards_only_gauge.increaseAllowance(accounts[1], 403, {"from": accounts[0]})
+
+    assert rewards_only_gauge.allowance(accounts[0], accounts[1]) == 503
+
+
+def test_decrease_allowance(accounts, rewards_only_gauge):
+    rewards_only_gauge.approve(accounts[1], 100, {"from": accounts[0]})
+    rewards_only_gauge.decreaseAllowance(accounts[1], 34, {"from": accounts[0]})
+
+    assert rewards_only_gauge.allowance(accounts[0], accounts[1]) == 66

--- a/tests/unitary/RewardsOnlyGauge/test_claim_historic_rewards.py
+++ b/tests/unitary/RewardsOnlyGauge/test_claim_historic_rewards.py
@@ -1,0 +1,118 @@
+import pytest
+from brownie import ZERO_ADDRESS
+
+from tests.conftest import approx
+
+REWARD = 10 ** 20
+WEEK = 7 * 86400
+LP_AMOUNT = 10 ** 18
+
+
+@pytest.fixture(scope="module")
+def reward_contract_2(CurveRewards, mock_lp_token, accounts, coin_a):
+    contract = CurveRewards.deploy(mock_lp_token, coin_a, {"from": accounts[0]})
+    contract.setRewardDistribution(accounts[0], {"from": accounts[0]})
+    yield contract
+
+
+@pytest.fixture(scope="module", autouse=True)
+def initial_setup(rewards_only_gauge, mock_lp_token, alice, reward_contract, coin_reward):
+    mock_lp_token.approve(rewards_only_gauge, LP_AMOUNT, {"from": alice})
+    rewards_only_gauge.deposit(LP_AMOUNT, {"from": alice})
+
+    sigs = [
+        reward_contract.stake.signature[2:],
+        reward_contract.withdraw.signature[2:],
+        reward_contract.getReward.signature[2:],
+    ]
+    sigs = f"0x{sigs[0]}{sigs[1]}{sigs[2]}{'00' * 20}"
+    rewards_only_gauge.set_rewards(
+        reward_contract, sigs, [coin_reward] + [ZERO_ADDRESS] * 7, {"from": alice}
+    )
+
+    coin_reward._mint_for_testing(REWARD, {"from": reward_contract})
+    reward_contract.notifyRewardAmount(REWARD, {"from": alice})
+
+
+def test_unset_and_claim_historic(alice, chain, coin_reward, reward_contract, rewards_only_gauge):
+    chain.sleep(WEEK)
+    rewards_only_gauge.set_rewards(ZERO_ADDRESS, "0x00", [ZERO_ADDRESS] * 8, {"from": alice})
+
+    rewards_only_gauge.claim_historic_rewards([coin_reward] + [ZERO_ADDRESS] * 7, {"from": alice})
+
+    reward = coin_reward.balanceOf(alice)
+    assert reward <= REWARD
+    assert approx(REWARD, reward, 1.001 / WEEK)
+
+
+def test_claim_historic_multiple(
+    alice, chain, coin_reward, coin_a, reward_contract, reward_contract_2, rewards_only_gauge
+):
+    chain.sleep(WEEK)
+
+    sigs = [
+        reward_contract.stake.signature[2:],
+        reward_contract.withdraw.signature[2:],
+        reward_contract.getReward.signature[2:],
+    ]
+    sigs = f"0x{sigs[0]}{sigs[1]}{sigs[2]}{'00' * 20}"
+    rewards_only_gauge.set_rewards(
+        reward_contract_2, sigs, [coin_a] + [ZERO_ADDRESS] * 7, {"from": alice}
+    )
+
+    coin_a._mint_for_testing(REWARD, {"from": reward_contract_2})
+    reward_contract_2.notifyRewardAmount(REWARD, {"from": alice})
+
+    chain.sleep(WEEK)
+    rewards_only_gauge.set_rewards(ZERO_ADDRESS, "0x00", [ZERO_ADDRESS] * 8, {"from": alice})
+
+    rewards_only_gauge.claim_historic_rewards(
+        [coin_reward, coin_a] + [ZERO_ADDRESS] * 6, {"from": alice}
+    )
+
+    for coin in (coin_reward, coin_a):
+        reward = coin.balanceOf(alice)
+        assert reward <= REWARD
+        assert approx(REWARD, reward, 1.001 / WEEK)
+
+
+def test_claim_historic_while_active(alice, bob, chain, rewards_only_gauge, coin_reward):
+    amount = rewards_only_gauge.balanceOf(alice) // 2
+
+    chain.sleep(int(86400 * 3.5))
+    rewards_only_gauge.transfer(bob, amount, {"from": alice})
+    chain.sleep(WEEK)
+
+    # this should have no effect
+    rewards_only_gauge.claim_historic_rewards([coin_reward] + [ZERO_ADDRESS] * 7, {"from": alice})
+    rewards_only_gauge.claim_historic_rewards([coin_reward] + [ZERO_ADDRESS] * 7, {"from": bob})
+
+    assert approx(coin_reward.balanceOf(alice) / REWARD, 0.5, 1e-4)
+    assert coin_reward.balanceOf(bob) == 0
+
+    # correctly claiming after `claim_historic_rewards` should still work as expected
+    rewards = []
+    for acct in (alice, bob):
+        rewards_only_gauge.claim_rewards({"from": acct})
+        rewards += [coin_reward.balanceOf(acct)]
+
+    assert sum(rewards) <= REWARD
+    assert approx(rewards[0] / rewards[1], 3, 1e-4)
+    assert approx(REWARD, sum(rewards), 1.001 / WEEK)
+
+
+def test_repeat_token(alice, bob, chain, coin_reward, reward_contract, rewards_only_gauge):
+    amount = rewards_only_gauge.balanceOf(alice) // 2
+
+    chain.sleep(int(86400 * 3.5))
+    rewards_only_gauge.transfer(bob, amount, {"from": alice})
+    chain.sleep(WEEK)
+
+    rewards_only_gauge.set_rewards(ZERO_ADDRESS, "0x00", [ZERO_ADDRESS] * 8, {"from": alice})
+
+    # repeated use of the same coin in `claim_historic_rewards` should have no effect
+    rewards_only_gauge.claim_historic_rewards([coin_reward] * 8, {"from": bob})
+
+    reward = coin_reward.balanceOf(bob)
+    assert reward <= REWARD
+    assert approx(reward / REWARD, 0.25, 1e-4)

--- a/tests/unitary/RewardsOnlyGauge/test_claim_no_reward_contract.py
+++ b/tests/unitary/RewardsOnlyGauge/test_claim_no_reward_contract.py
@@ -1,0 +1,85 @@
+import pytest
+from brownie import ZERO_ADDRESS
+
+from tests.conftest import approx
+
+REWARD = 10 ** 20
+WEEK = 7 * 86400
+LP_AMOUNT = 10 ** 18
+
+
+@pytest.fixture(scope="module", autouse=True)
+def initial_setup(
+    alice, bob, coin_reward, mock_lp_token, rewards_only_gauge, minter,
+):
+    # deposit into gauge
+    mock_lp_token.transfer(bob, LP_AMOUNT, {"from": alice})
+    mock_lp_token.approve(rewards_only_gauge, LP_AMOUNT, {"from": bob})
+    rewards_only_gauge.deposit(LP_AMOUNT, {"from": bob})
+
+    rewards_only_gauge.set_rewards(
+        ZERO_ADDRESS, "0x00", [coin_reward] + [ZERO_ADDRESS] * 7, {"from": alice}
+    )
+
+    # mint rewards directly into the contract (no notifiaction)
+    coin_reward._mint_for_testing(REWARD, {"from": rewards_only_gauge})
+
+
+def test_claim_one_lp(bob, chain, rewards_only_gauge, coin_reward):
+    chain.sleep(WEEK)
+
+    rewards_only_gauge.withdraw(LP_AMOUNT, {"from": bob})
+    rewards_only_gauge.claim_rewards({"from": bob})
+
+    reward = coin_reward.balanceOf(bob)
+    assert reward <= REWARD
+    assert approx(REWARD, reward, 1.001 / WEEK)  # ganache-cli jitter of 1 s
+
+
+def test_claim_for_other(bob, charlie, chain, rewards_only_gauge, coin_reward):
+    rewards_only_gauge.withdraw(LP_AMOUNT, {"from": bob})
+    rewards_only_gauge.claim_rewards(bob, {"from": charlie})
+
+    assert coin_reward.balanceOf(charlie) == 0
+
+    reward = coin_reward.balanceOf(bob)
+    assert reward <= REWARD
+    assert approx(REWARD, reward, 1.001 / WEEK)  # ganache-cli jitter of 1 s
+
+
+def test_claim_for_other_no_reward(bob, charlie, chain, rewards_only_gauge, coin_reward):
+    rewards_only_gauge.claim_rewards(charlie, {"from": bob})
+
+    assert coin_reward.balanceOf(bob) == 0
+    assert coin_reward.balanceOf(charlie) == 0
+
+
+def test_claim_two_lp(
+    alice, bob, chain, rewards_only_gauge, mock_lp_token, coin_reward, no_call_coverage
+):
+    # Deposit
+    mock_lp_token.approve(rewards_only_gauge, LP_AMOUNT, {"from": alice})
+    rewards_only_gauge.deposit(LP_AMOUNT, {"from": alice})
+
+    chain.sleep(WEEK)
+    chain.mine()
+
+    # Calculate rewards
+    claimable_rewards = [
+        rewards_only_gauge.claimable_reward.call(acc, coin_reward, {"from": acc})
+        for acc in (alice, bob)
+    ]
+
+    # Claim rewards
+    rewards = []
+    for acct in (alice, bob):
+        rewards_only_gauge.claim_rewards({"from": acct})
+        rewards += [coin_reward.balanceOf(acct)]
+
+    # Calculation == results
+    assert tuple(claimable_rewards) == tuple(rewards)
+
+    # Approximately equal apart from what caused by 1 s ganache-cli jitter
+    assert sum(rewards) <= REWARD
+    assert approx(sum(rewards), REWARD, 1.001 / WEEK)  # ganache-cli jitter of 1 s
+    assert approx(rewards[0], rewards[1], 2.002 * WEEK)

--- a/tests/unitary/RewardsOnlyGauge/test_claim_rewards_multiple.py
+++ b/tests/unitary/RewardsOnlyGauge/test_claim_rewards_multiple.py
@@ -1,0 +1,132 @@
+import pytest
+from brownie import ZERO_ADDRESS, compile_source
+
+from tests.conftest import approx
+
+REWARD = 10 ** 20
+WEEK = 7 * 86400
+LP_AMOUNT = 10 ** 18
+
+
+code = """
+# @version 0.2.7
+
+from vyper.interfaces import ERC20
+
+first: address
+second: address
+
+@external
+def __init__(_first: address, _second: address):
+    self.first = _first
+    self.second = _second
+
+@external
+def claim_tokens() -> bool:
+    ERC20(self.first).transfer(msg.sender, ERC20(self.first).balanceOf(self))
+    ERC20(self.second).transfer(msg.sender, ERC20(self.second).balanceOf(self))
+
+    return True
+"""
+
+
+@pytest.fixture(scope="module")
+def reward_contract(alice, coin_a, coin_b):
+    contract = compile_source(code).Vyper.deploy(coin_a, coin_b, {"from": alice})
+    coin_a._mint_for_testing(REWARD, {"from": contract})
+    coin_b._mint_for_testing(REWARD, {"from": contract})
+
+    yield contract
+
+
+@pytest.fixture(scope="module", autouse=True)
+def initial_setup(
+    alice,
+    bob,
+    chain,
+    rewards_only_gauge,
+    reward_contract,
+    coin_reward,
+    coin_a,
+    coin_b,
+    mock_lp_token,
+):
+
+    sigs = f"0x{'00' * 4}{'00' * 4}{reward_contract.claim_tokens.signature[2:]}{'00' * 20}"
+
+    rewards_only_gauge.set_rewards(
+        reward_contract, sigs, [coin_a, coin_reward, coin_b] + [ZERO_ADDRESS] * 5, {"from": alice},
+    )
+
+    # Deposit
+    mock_lp_token.transfer(bob, LP_AMOUNT, {"from": alice})
+    mock_lp_token.approve(rewards_only_gauge, LP_AMOUNT, {"from": bob})
+    rewards_only_gauge.deposit(LP_AMOUNT, {"from": bob})
+
+
+def test_claim_one_lp(bob, chain, rewards_only_gauge, coin_a, coin_b):
+    chain.sleep(WEEK)
+
+    rewards_only_gauge.withdraw(LP_AMOUNT, {"from": bob})
+    rewards_only_gauge.claim_rewards({"from": bob})
+
+    for coin in (coin_a, coin_b):
+        reward = coin.balanceOf(bob)
+        assert reward <= REWARD
+        assert approx(REWARD, reward, 1.001 / WEEK)  # ganache-cli jitter of 1 s
+
+
+def test_claim_for_other(bob, charlie, chain, rewards_only_gauge, coin_a, coin_b):
+    chain.sleep(WEEK)
+
+    rewards_only_gauge.withdraw(LP_AMOUNT, {"from": bob})
+    rewards_only_gauge.claim_rewards(bob, {"from": charlie})
+
+    assert coin_a.balanceOf(charlie) == 0
+
+    for coin in (coin_a, coin_b):
+        reward = coin.balanceOf(bob)
+        assert reward <= REWARD
+        assert approx(REWARD, reward, 1.001 / WEEK)  # ganache-cli jitter of 1 s
+
+
+def test_claim_for_other_no_reward(bob, charlie, chain, rewards_only_gauge, coin_a, coin_b):
+    chain.sleep(WEEK)
+    rewards_only_gauge.claim_rewards(charlie, {"from": bob})
+
+    assert coin_a.balanceOf(bob) == 0
+    assert coin_a.balanceOf(charlie) == 0
+
+    assert coin_b.balanceOf(bob) == 0
+    assert coin_b.balanceOf(charlie) == 0
+
+
+def test_claim_two_lp(
+    alice,
+    bob,
+    chain,
+    rewards_only_gauge,
+    mock_lp_token,
+    coin_a,
+    coin_b,
+    reward_contract,
+    no_call_coverage,
+):
+
+    # Deposit
+    mock_lp_token.approve(rewards_only_gauge, LP_AMOUNT, {"from": alice})
+    rewards_only_gauge.deposit(LP_AMOUNT, {"from": alice})
+
+    coin_a._mint_for_testing(REWARD, {"from": reward_contract})
+    coin_b._mint_for_testing(REWARD, {"from": reward_contract})
+
+    chain.sleep(WEEK)
+    chain.mine()
+
+    for acct in (alice, bob):
+        rewards_only_gauge.claim_rewards({"from": acct})
+
+    for coin in (coin_a, coin_b):
+        # Calculate rewards
+        assert coin.balanceOf(bob) > coin.balanceOf(alice) > 0
+        assert coin.balanceOf(rewards_only_gauge) == 0

--- a/tests/unitary/RewardsOnlyGauge/test_claim_rewards_none.py
+++ b/tests/unitary/RewardsOnlyGauge/test_claim_rewards_none.py
@@ -1,0 +1,46 @@
+from brownie import ZERO_ADDRESS
+
+REWARD = 10 ** 20
+WEEK = 7 * 86400
+LP_AMOUNT = 10 ** 18
+
+
+def test_claim_no_deposit(
+    alice, bob, chain, rewards_only_gauge, mock_lp_token, reward_contract, coin_reward
+):
+    # Fund
+    mock_lp_token.approve(rewards_only_gauge, LP_AMOUNT, {"from": alice})
+    rewards_only_gauge.deposit(LP_AMOUNT, {"from": alice})
+
+    coin_reward._mint_for_testing(REWARD, {"from": alice})
+    coin_reward.transfer(reward_contract, REWARD, {"from": alice})
+    reward_contract.notifyRewardAmount(REWARD, {"from": alice})
+
+    rewards_only_gauge.set_rewards(
+        reward_contract,
+        "0xa694fc3a2e1a7d4d3d18b9120000000000000000000000000000000000000000",
+        [coin_reward] + [ZERO_ADDRESS] * 7,
+        {"from": alice},
+    )
+
+    chain.sleep(WEEK)
+
+    rewards_only_gauge.claim_rewards({"from": bob})
+
+    assert coin_reward.balanceOf(bob) == 0
+
+
+def test_claim_no_rewards(
+    alice, bob, chain, rewards_only_gauge, mock_lp_token, reward_contract, coin_reward
+):
+    # Deposit
+    mock_lp_token.transfer(bob, LP_AMOUNT, {"from": alice})
+    mock_lp_token.approve(rewards_only_gauge, LP_AMOUNT, {"from": bob})
+    rewards_only_gauge.deposit(LP_AMOUNT, {"from": bob})
+
+    chain.sleep(WEEK)
+
+    rewards_only_gauge.withdraw(LP_AMOUNT, {"from": bob})
+    rewards_only_gauge.claim_rewards({"from": bob})
+
+    assert coin_reward.balanceOf(bob) == 0

--- a/tests/unitary/RewardsOnlyGauge/test_claim_rewards_transfer.py
+++ b/tests/unitary/RewardsOnlyGauge/test_claim_rewards_transfer.py
@@ -1,0 +1,134 @@
+import pytest
+from brownie import ZERO_ADDRESS
+
+from tests.conftest import approx
+
+REWARD = 10 ** 20
+WEEK = 7 * 86400
+
+
+@pytest.fixture(scope="module", autouse=True)
+def initial_setup(
+    alice,
+    chain,
+    coin_reward,
+    reward_contract,
+    token,
+    mock_lp_token,
+    rewards_only_gauge,
+    gauge_controller,
+    minter,
+):
+    # gauge setup
+    token.set_minter(minter, {"from": alice})
+    gauge_controller.add_type(b"Liquidity", 10 ** 10, {"from": alice})
+    gauge_controller.add_gauge(rewards_only_gauge, 0, 0, {"from": alice})
+
+    # deposit into gauge
+    mock_lp_token.approve(rewards_only_gauge, 2 ** 256 - 1, {"from": alice})
+    rewards_only_gauge.deposit(10 ** 18, {"from": alice})
+
+    # add rewards
+    sigs = [
+        reward_contract.stake.signature[2:],
+        reward_contract.withdraw.signature[2:],
+        reward_contract.getReward.signature[2:],
+    ]
+    sigs = f"0x{sigs[0]}{sigs[1]}{sigs[2]}{'00' * 20}"
+
+    rewards_only_gauge.set_rewards(
+        reward_contract, sigs, [coin_reward] + [ZERO_ADDRESS] * 7, {"from": alice}
+    )
+
+    # fund rewards
+    coin_reward._mint_for_testing(REWARD, {"from": reward_contract})
+    reward_contract.notifyRewardAmount(REWARD, {"from": alice})
+
+    # sleep half way through the reward period
+    chain.sleep(int(86400 * 3.5))
+
+
+def test_transfer_triggers_claim_for_sender(alice, bob, chain, rewards_only_gauge, coin_reward):
+    amount = rewards_only_gauge.balanceOf(alice)
+
+    rewards_only_gauge.transfer(bob, amount, {"from": alice})
+
+    reward = coin_reward.balanceOf(alice)
+    assert approx(REWARD // 2, reward, 1e-4)
+
+
+def test_transfer_triggers_claim_for_receiver(alice, bob, chain, rewards_only_gauge, coin_reward):
+    amount = rewards_only_gauge.balanceOf(alice) // 2
+
+    rewards_only_gauge.transfer(bob, amount, {"from": alice})
+    chain.sleep(WEEK)
+    rewards_only_gauge.transfer(alice, amount, {"from": bob})
+
+    rewards = []
+    for acct in (alice, bob):
+        rewards_only_gauge.claim_rewards({"from": acct})
+        rewards += [coin_reward.balanceOf(acct)]
+
+    assert sum(rewards) <= REWARD
+    assert approx(rewards[0] / rewards[1], 3, 1e-4)
+    assert approx(REWARD, sum(rewards), 1.001 / WEEK)
+
+
+def test_transfer_partial_balance(alice, bob, chain, rewards_only_gauge, coin_reward):
+    amount = rewards_only_gauge.balanceOf(alice) // 2
+
+    rewards_only_gauge.transfer(bob, amount, {"from": alice})
+    chain.sleep(WEEK)
+
+    rewards = []
+    for acct in (alice, bob):
+        rewards_only_gauge.claim_rewards({"from": acct})
+        rewards += [coin_reward.balanceOf(acct)]
+
+    assert sum(rewards) <= REWARD
+    assert approx(rewards[0] / rewards[1], 3, 1e-4)
+    assert approx(REWARD, sum(rewards), 1.001 / WEEK)
+
+
+def test_transfer_full_balance(alice, bob, chain, rewards_only_gauge, coin_reward):
+    amount = rewards_only_gauge.balanceOf(alice)
+
+    rewards_only_gauge.transfer(bob, amount, {"from": alice})
+    chain.sleep(WEEK)
+
+    rewards = []
+    for acct in (alice, bob):
+        rewards_only_gauge.claim_rewards({"from": acct})
+        rewards += [coin_reward.balanceOf(acct)]
+
+    assert sum(rewards) <= REWARD
+    assert approx(rewards[0], rewards[1], 1e-4)
+    assert approx(REWARD, sum(rewards), 1.001 / WEEK)
+
+
+def test_transfer_zero_tokens(alice, bob, chain, rewards_only_gauge, coin_reward):
+    rewards_only_gauge.transfer(bob, 0, {"from": alice})
+    chain.sleep(WEEK)
+
+    for acct in (alice, bob):
+        rewards_only_gauge.claim_rewards({"from": acct})
+
+    reward = coin_reward.balanceOf(alice)
+
+    assert coin_reward.balanceOf(bob) == 0
+    assert reward <= REWARD
+    assert approx(REWARD, reward, 1.001 / WEEK)
+
+
+def test_transfer_to_self(alice, chain, rewards_only_gauge, coin_reward):
+    sender_balance = rewards_only_gauge.balanceOf(alice)
+    amount = sender_balance // 4
+
+    rewards_only_gauge.transfer(alice, amount, {"from": alice})
+    chain.sleep(WEEK)
+
+    rewards_only_gauge.claim_rewards({"from": alice})
+    reward = coin_reward.balanceOf(alice)
+
+    assert reward <= REWARD
+    assert approx(REWARD, reward, 1.001 / WEEK)

--- a/tests/unitary/RewardsOnlyGauge/test_claim_rewards_unipool.py
+++ b/tests/unitary/RewardsOnlyGauge/test_claim_rewards_unipool.py
@@ -1,0 +1,107 @@
+import pytest
+from brownie import ZERO_ADDRESS
+
+from tests.conftest import approx
+
+REWARD = 10 ** 20
+WEEK = 7 * 86400
+LP_AMOUNT = 10 ** 18
+
+
+@pytest.fixture(scope="module", autouse=True)
+def initial_setup(
+    alice,
+    bob,
+    chain,
+    coin_reward,
+    reward_contract,
+    token,
+    mock_lp_token,
+    gauge_v2,
+    gauge_controller,
+    minter,
+):
+    # gauge setup
+    token.set_minter(minter, {"from": alice})
+    gauge_controller.add_type(b"Liquidity", 10 ** 10, {"from": alice})
+    gauge_controller.add_gauge(gauge_v2, 0, 0, {"from": alice})
+
+    # deposit into gauge
+    mock_lp_token.transfer(bob, LP_AMOUNT, {"from": alice})
+    mock_lp_token.approve(gauge_v2, LP_AMOUNT, {"from": bob})
+    gauge_v2.deposit(LP_AMOUNT, {"from": bob})
+
+    # add rewards
+    sigs = [
+        reward_contract.stake.signature[2:],
+        reward_contract.withdraw.signature[2:],
+        reward_contract.getReward.signature[2:],
+    ]
+    sigs = f"0x{sigs[0]}{sigs[1]}{sigs[2]}{'00' * 20}"
+
+    gauge_v2.set_rewards(reward_contract, sigs, [coin_reward] + [ZERO_ADDRESS] * 7, {"from": alice})
+
+    # fund rewards
+    coin_reward._mint_for_testing(REWARD, {"from": reward_contract})
+    reward_contract.notifyRewardAmount(REWARD, {"from": alice})
+
+
+def test_claim_one_lp(bob, chain, gauge_v2, coin_reward):
+    chain.sleep(WEEK)
+
+    gauge_v2.withdraw(LP_AMOUNT, {"from": bob})
+    gauge_v2.claim_rewards({"from": bob})
+
+    reward = coin_reward.balanceOf(bob)
+    assert reward <= REWARD
+    assert approx(REWARD, reward, 1.001 / WEEK)  # ganache-cli jitter of 1 s
+
+
+def test_claim_for_other(bob, charlie, chain, gauge_v2, coin_reward):
+    chain.sleep(WEEK)
+
+    gauge_v2.withdraw(LP_AMOUNT, {"from": bob})
+    gauge_v2.claim_rewards(bob, {"from": charlie})
+
+    assert coin_reward.balanceOf(charlie) == 0
+
+    reward = coin_reward.balanceOf(bob)
+    assert reward <= REWARD
+    assert approx(REWARD, reward, 1.001 / WEEK)  # ganache-cli jitter of 1 s
+
+
+def test_claim_for_other_no_reward(bob, charlie, chain, gauge_v2, coin_reward):
+    chain.sleep(WEEK)
+    gauge_v2.claim_rewards(charlie, {"from": bob})
+
+    assert coin_reward.balanceOf(bob) == 0
+    assert coin_reward.balanceOf(charlie) == 0
+
+
+def test_claim_two_lp(alice, bob, chain, gauge_v2, mock_lp_token, coin_reward, no_call_coverage):
+
+    # Deposit
+    mock_lp_token.approve(gauge_v2, LP_AMOUNT, {"from": alice})
+    gauge_v2.deposit(LP_AMOUNT, {"from": alice})
+
+    chain.sleep(WEEK)
+    chain.mine()
+
+    # Calculate rewards
+    claimable_rewards = [
+        gauge_v2.claimable_reward.call(acc, coin_reward, {"from": acc}) for acc in (alice, bob)
+    ]
+
+    # Claim rewards
+    rewards = []
+    for acct in (alice, bob):
+        gauge_v2.claim_rewards({"from": acct})
+        rewards += [coin_reward.balanceOf(acct)]
+
+    # Calculation == results
+    assert tuple(claimable_rewards) == tuple(rewards)
+
+    # Approximately equal apart from what caused by 1 s ganache-cli jitter
+    assert sum(rewards) <= REWARD
+    assert approx(sum(rewards), REWARD, 1.001 / WEEK)  # ganache-cli jitter of 1 s
+    assert approx(rewards[0], rewards[1], 2.002 * WEEK)

--- a/tests/unitary/RewardsOnlyGauge/test_deposit_for.py
+++ b/tests/unitary/RewardsOnlyGauge/test_deposit_for.py
@@ -1,0 +1,39 @@
+import brownie
+
+
+def test_deposit_for(accounts, rewards_only_gauge, mock_lp_token):
+    mock_lp_token.approve(rewards_only_gauge, 2 ** 256 - 1, {"from": accounts[0]})
+    balance = mock_lp_token.balanceOf(accounts[0])
+    rewards_only_gauge.set_approve_deposit(accounts[0], True, {"from": accounts[1]})
+    rewards_only_gauge.deposit(100000, accounts[1], {"from": accounts[0]})
+
+    assert mock_lp_token.balanceOf(rewards_only_gauge) == 100000
+    assert mock_lp_token.balanceOf(accounts[0]) == balance - 100000
+    assert rewards_only_gauge.totalSupply() == 100000
+    assert rewards_only_gauge.balanceOf(accounts[1]) == 100000
+
+
+def test_set_approve_deposit_initial(accounts, rewards_only_gauge):
+    assert rewards_only_gauge.approved_to_deposit(accounts[0], accounts[1]) is False
+
+
+def test_set_approve_deposit_true(accounts, rewards_only_gauge):
+    rewards_only_gauge.set_approve_deposit(accounts[0], True, {"from": accounts[1]})
+    assert rewards_only_gauge.approved_to_deposit(accounts[0], accounts[1]) is True
+
+
+def test_set_approve_deposit_false(accounts, rewards_only_gauge):
+    rewards_only_gauge.set_approve_deposit(accounts[0], False, {"from": accounts[1]})
+    assert rewards_only_gauge.approved_to_deposit(accounts[0], accounts[1]) is False
+
+
+def test_set_approve_deposit_toggle(accounts, rewards_only_gauge):
+    for value in [True, True, False, False, True, False, True]:
+        rewards_only_gauge.set_approve_deposit(accounts[0], value, {"from": accounts[1]})
+        assert rewards_only_gauge.approved_to_deposit(accounts[0], accounts[1]) is value
+
+
+def test_not_approved(accounts, rewards_only_gauge, mock_lp_token):
+    mock_lp_token.approve(rewards_only_gauge, 2 ** 256 - 1, {"from": accounts[0]})
+    with brownie.reverts("Not approved"):
+        rewards_only_gauge.deposit(100000, accounts[1], {"from": accounts[0]})

--- a/tests/unitary/RewardsOnlyGauge/test_deposit_withdraw.py
+++ b/tests/unitary/RewardsOnlyGauge/test_deposit_withdraw.py
@@ -1,0 +1,68 @@
+import brownie
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def deposit_setup(accounts, rewards_only_gauge, mock_lp_token):
+    mock_lp_token.approve(rewards_only_gauge, 2 ** 256 - 1, {"from": accounts[0]})
+
+
+def test_deposit(accounts, rewards_only_gauge, mock_lp_token):
+    balance = mock_lp_token.balanceOf(accounts[0])
+    rewards_only_gauge.deposit(100000, {"from": accounts[0]})
+
+    assert mock_lp_token.balanceOf(rewards_only_gauge) == 100000
+    assert mock_lp_token.balanceOf(accounts[0]) == balance - 100000
+    assert rewards_only_gauge.totalSupply() == 100000
+    assert rewards_only_gauge.balanceOf(accounts[0]) == 100000
+
+
+def test_deposit_zero(accounts, rewards_only_gauge, mock_lp_token):
+    balance = mock_lp_token.balanceOf(accounts[0])
+    rewards_only_gauge.deposit(0, {"from": accounts[0]})
+
+    assert mock_lp_token.balanceOf(rewards_only_gauge) == 0
+    assert mock_lp_token.balanceOf(accounts[0]) == balance
+    assert rewards_only_gauge.totalSupply() == 0
+    assert rewards_only_gauge.balanceOf(accounts[0]) == 0
+
+
+def test_deposit_insufficient_balance(accounts, rewards_only_gauge, mock_lp_token):
+    with brownie.reverts():
+        rewards_only_gauge.deposit(100000, {"from": accounts[1]})
+
+
+def test_withdraw(accounts, rewards_only_gauge, mock_lp_token):
+    balance = mock_lp_token.balanceOf(accounts[0])
+
+    rewards_only_gauge.deposit(100000, {"from": accounts[0]})
+    rewards_only_gauge.withdraw(100000, {"from": accounts[0]})
+
+    assert mock_lp_token.balanceOf(rewards_only_gauge) == 0
+    assert mock_lp_token.balanceOf(accounts[0]) == balance
+    assert rewards_only_gauge.totalSupply() == 0
+    assert rewards_only_gauge.balanceOf(accounts[0]) == 0
+
+
+def test_withdraw_zero(accounts, rewards_only_gauge, mock_lp_token):
+    balance = mock_lp_token.balanceOf(accounts[0])
+    rewards_only_gauge.deposit(100000, {"from": accounts[0]})
+    rewards_only_gauge.withdraw(0, {"from": accounts[0]})
+
+    assert mock_lp_token.balanceOf(rewards_only_gauge) == 100000
+    assert mock_lp_token.balanceOf(accounts[0]) == balance - 100000
+    assert rewards_only_gauge.totalSupply() == 100000
+    assert rewards_only_gauge.balanceOf(accounts[0]) == 100000
+
+
+def test_withdraw_new_epoch(accounts, chain, rewards_only_gauge, mock_lp_token):
+    balance = mock_lp_token.balanceOf(accounts[0])
+
+    rewards_only_gauge.deposit(100000, {"from": accounts[0]})
+    chain.sleep(86400 * 400)
+    rewards_only_gauge.withdraw(100000, {"from": accounts[0]})
+
+    assert mock_lp_token.balanceOf(rewards_only_gauge) == 0
+    assert mock_lp_token.balanceOf(accounts[0]) == balance
+    assert rewards_only_gauge.totalSupply() == 0
+    assert rewards_only_gauge.balanceOf(accounts[0]) == 0

--- a/tests/unitary/RewardsOnlyGauge/test_set_rewards.py
+++ b/tests/unitary/RewardsOnlyGauge/test_set_rewards.py
@@ -1,0 +1,178 @@
+import brownie
+import pytest
+from brownie import ZERO_ADDRESS
+
+REWARD = 10 ** 20
+WEEK = 7 * 86400
+LP_AMOUNT = 10 ** 18
+
+
+@pytest.fixture(scope="module", autouse=True)
+def initial_setup(rewards_only_gauge, mock_lp_token, alice):
+    mock_lp_token.approve(rewards_only_gauge, LP_AMOUNT, {"from": alice})
+    rewards_only_gauge.deposit(LP_AMOUNT, {"from": alice})
+
+
+def test_set_rewards_with_deposit(
+    alice, coin_reward, reward_contract, mock_lp_token, rewards_only_gauge
+):
+    sigs = [
+        reward_contract.stake.signature[2:],
+        reward_contract.withdraw.signature[2:],
+        reward_contract.getReward.signature[2:],
+    ]
+    sigs = f"0x{sigs[0]}{sigs[1]}{sigs[2]}{'00' * 20}"
+
+    rewards_only_gauge.set_rewards(
+        reward_contract, sigs, [coin_reward] + [ZERO_ADDRESS] * 7, {"from": alice}
+    )
+
+    assert mock_lp_token.balanceOf(reward_contract) == LP_AMOUNT
+    assert rewards_only_gauge.reward_contract() == reward_contract
+    assert rewards_only_gauge.reward_tokens(0) == coin_reward
+    assert rewards_only_gauge.reward_tokens(1) == ZERO_ADDRESS
+
+
+def test_set_rewards_no_deposit(
+    alice, coin_reward, reward_contract, mock_lp_token, rewards_only_gauge
+):
+    sigs = f"0x{'00' * 4}{'00' * 4}{reward_contract.getReward.signature[2:]}{'00' * 20}"
+    rewards_only_gauge.set_rewards(
+        reward_contract, sigs, [coin_reward] + [ZERO_ADDRESS] * 7, {"from": alice}
+    )
+
+    assert mock_lp_token.balanceOf(rewards_only_gauge) == LP_AMOUNT
+    assert rewards_only_gauge.reward_contract() == reward_contract
+    assert rewards_only_gauge.reward_tokens(0) == coin_reward
+    assert rewards_only_gauge.reward_tokens(1) == ZERO_ADDRESS
+
+
+def test_multiple_reward_tokens(
+    alice, coin_reward, coin_a, coin_b, reward_contract, rewards_only_gauge
+):
+    sigs = f"0x{'00' * 4}{'00' * 4}{reward_contract.getReward.signature[2:]}{'00' * 20}"
+    reward_tokens = [coin_reward, coin_a, coin_b] + [ZERO_ADDRESS] * 5
+
+    rewards_only_gauge.set_rewards(reward_contract, sigs, reward_tokens, {"from": alice})
+
+    assert reward_tokens == [rewards_only_gauge.reward_tokens(i) for i in range(8)]
+
+
+def test_multiple_tokens_no_reward_contract(
+    alice, coin_reward, coin_a, coin_b, reward_contract, rewards_only_gauge
+):
+    reward_tokens = [coin_reward, coin_a, coin_b] + [ZERO_ADDRESS] * 5
+
+    rewards_only_gauge.set_rewards(ZERO_ADDRESS, "0x00", reward_tokens, {"from": alice})
+
+    assert reward_tokens == [rewards_only_gauge.reward_tokens(i) for i in range(8)]
+    assert rewards_only_gauge.reward_contract() == ZERO_ADDRESS
+
+
+def test_modify_reward_tokens_less(
+    alice, coin_reward, coin_a, coin_b, reward_contract, rewards_only_gauge
+):
+    sigs = f"0x{'00' * 4}{'00' * 4}{reward_contract.getReward.signature[2:]}{'00' * 20}"
+    rewards_only_gauge.set_rewards(
+        reward_contract, sigs, [coin_reward, coin_a, coin_b] + [ZERO_ADDRESS] * 5, {"from": alice},
+    )
+
+    reward_tokens = [coin_a] + [ZERO_ADDRESS] * 7
+    rewards_only_gauge.set_rewards(reward_contract, sigs, reward_tokens, {"from": alice})
+
+    assert reward_tokens == [rewards_only_gauge.reward_tokens(i) for i in range(8)]
+
+
+def test_modify_reward_tokens_more(
+    alice, coin_reward, coin_a, coin_b, reward_contract, rewards_only_gauge
+):
+    sigs = f"0x{'00' * 4}{'00' * 4}{reward_contract.getReward.signature[2:]}{'00' * 20}"
+    rewards_only_gauge.set_rewards(
+        reward_contract, sigs, [coin_a] + [ZERO_ADDRESS] * 7, {"from": alice}
+    )
+
+    reward_tokens = [coin_reward, coin_a, coin_b] + [ZERO_ADDRESS] * 5
+    rewards_only_gauge.set_rewards(reward_contract, sigs, reward_tokens, {"from": alice})
+
+    assert reward_tokens == [rewards_only_gauge.reward_tokens(i) for i in range(8)]
+
+
+def test_not_a_contract(alice, coin_reward, rewards_only_gauge):
+    with brownie.reverts("dev: not a contract"):
+        rewards_only_gauge.set_rewards(
+            alice, "0x00", [coin_reward] + [ZERO_ADDRESS] * 7, {"from": alice}
+        )
+
+
+def test_deposit_no_withdraw(alice, coin_reward, reward_contract, rewards_only_gauge):
+    sigs = [
+        reward_contract.stake.signature[2:],
+        reward_contract.withdraw.signature[2:],
+        reward_contract.getReward.signature[2:],
+    ]
+    sigs = f"0x{sigs[0]}{'00' * 4}{sigs[2]}{'00' * 20}"
+
+    with brownie.reverts("dev: failed withdraw"):
+        rewards_only_gauge.set_rewards(
+            reward_contract, sigs, [coin_reward] + [ZERO_ADDRESS] * 7, {"from": alice}
+        )
+
+
+def test_withdraw_no_deposit(alice, coin_reward, reward_contract, rewards_only_gauge):
+    sigs = [
+        reward_contract.stake.signature[2:],
+        reward_contract.withdraw.signature[2:],
+        reward_contract.getReward.signature[2:],
+    ]
+    sigs = f"0x{'00' * 4}{sigs[1]}{sigs[2]}{'00' * 20}"
+
+    with brownie.reverts("dev: withdraw without deposit"):
+        rewards_only_gauge.set_rewards(
+            reward_contract, sigs, [coin_reward] + [ZERO_ADDRESS] * 7, {"from": alice}
+        )
+
+
+def test_bad_deposit_sig(alice, coin_reward, reward_contract, rewards_only_gauge):
+    sigs = [
+        "12345678",
+        reward_contract.withdraw.signature[2:],
+        reward_contract.getReward.signature[2:],
+    ]
+    sigs = f"0x{sigs[0]}{'00' * 4}{sigs[2]}{'00' * 20}"
+
+    with brownie.reverts("dev: failed deposit"):
+        rewards_only_gauge.set_rewards(
+            reward_contract, sigs, [coin_reward] + [ZERO_ADDRESS] * 7, {"from": alice}
+        )
+
+
+def test_bad_withdraw_sig(alice, coin_reward, reward_contract, rewards_only_gauge):
+    sigs = [
+        reward_contract.stake.signature[2:],
+        "12345678",
+        reward_contract.getReward.signature[2:],
+    ]
+    sigs = f"0x{sigs[0]}{'00' * 4}{sigs[2]}{'00' * 20}"
+
+    with brownie.reverts("dev: failed withdraw"):
+        rewards_only_gauge.set_rewards(
+            reward_contract, sigs, [coin_reward] + [ZERO_ADDRESS] * 7, {"from": alice}
+        )
+
+
+def test_no_reward_token(alice, reward_contract, rewards_only_gauge):
+    with brownie.reverts("dev: no reward token"):
+        rewards_only_gauge.set_rewards(reward_contract, "0x00", [ZERO_ADDRESS] * 8, {"from": alice})
+
+
+def test_bad_claim_sig(alice, coin_reward, reward_contract, rewards_only_gauge):
+    sigs = [
+        reward_contract.stake.signature[2:],
+        reward_contract.withdraw.signature[2:],
+    ]
+    sigs = f"0x{sigs[0]}{sigs[1]}{'00' * 4}{'00' * 20}"
+
+    with brownie.reverts("dev: bad claim sig"):
+        rewards_only_gauge.set_rewards(
+            reward_contract, sigs, [coin_reward] + [ZERO_ADDRESS] * 7, {"from": alice}
+        )

--- a/tests/unitary/RewardsOnlyGauge/test_set_rewards_deposit.py
+++ b/tests/unitary/RewardsOnlyGauge/test_set_rewards_deposit.py
@@ -1,0 +1,154 @@
+import brownie
+import pytest
+from brownie import ZERO_ADDRESS
+
+from tests.conftest import approx
+
+REWARD = 10 ** 20
+WEEK = 7 * 86400
+LP_AMOUNT = 10 ** 18
+
+
+@pytest.fixture(scope="module")
+def reward_contract_2(CurveRewards, mock_lp_token, accounts, coin_a):
+    contract = CurveRewards.deploy(mock_lp_token, coin_a, {"from": accounts[0]})
+    contract.setRewardDistribution(accounts[0], {"from": accounts[0]})
+    yield contract
+
+
+@pytest.fixture(scope="module", autouse=True)
+def initial_setup(rewards_only_gauge, mock_lp_token, alice, reward_contract, coin_reward):
+    mock_lp_token.approve(rewards_only_gauge, 2 ** 256 - 1, {"from": alice})
+    rewards_only_gauge.deposit(1, {"from": alice})
+
+    sigs = [
+        reward_contract.stake.signature[2:],
+        reward_contract.withdraw.signature[2:],
+        reward_contract.getReward.signature[2:],
+    ]
+    sigs = f"0x{sigs[0]}{sigs[1]}{sigs[2]}{'00' * 20}"
+    rewards_only_gauge.set_rewards(
+        reward_contract, sigs, [coin_reward] + [ZERO_ADDRESS] * 7, {"from": alice}
+    )
+
+    rewards_only_gauge.withdraw(1, {"from": alice})
+
+
+def test_unset_no_totalsupply(
+    alice, coin_reward, reward_contract, rewards_only_gauge, mock_lp_token
+):
+    rewards_only_gauge.set_rewards(ZERO_ADDRESS, "0x00", [ZERO_ADDRESS] * 8, {"from": alice})
+
+    assert mock_lp_token.allowance(rewards_only_gauge, reward_contract) == 0
+    assert rewards_only_gauge.reward_contract() == ZERO_ADDRESS
+    assert [rewards_only_gauge.reward_tokens(i) for i in range(8)] == [ZERO_ADDRESS] * 8
+
+
+def test_unset_with_totalsupply(
+    alice, coin_reward, reward_contract, rewards_only_gauge, mock_lp_token
+):
+    rewards_only_gauge.deposit(LP_AMOUNT, {"from": alice})
+    rewards_only_gauge.set_rewards(ZERO_ADDRESS, "0x00", [ZERO_ADDRESS] * 8, {"from": alice})
+
+    assert mock_lp_token.allowance(rewards_only_gauge, reward_contract) == 0
+    assert mock_lp_token.balanceOf(rewards_only_gauge) == LP_AMOUNT
+    assert rewards_only_gauge.reward_contract() == ZERO_ADDRESS
+    assert [rewards_only_gauge.reward_tokens(i) for i in range(8)] == [ZERO_ADDRESS] * 8
+
+
+def test_unsetting_claims(alice, chain, coin_reward, reward_contract, rewards_only_gauge):
+    rewards_only_gauge.deposit(LP_AMOUNT, {"from": alice})
+
+    coin_reward._mint_for_testing(REWARD, {"from": reward_contract})
+    reward_contract.notifyRewardAmount(REWARD, {"from": alice})
+
+    chain.sleep(WEEK)
+
+    rewards_only_gauge.set_rewards(ZERO_ADDRESS, "0x00", [ZERO_ADDRESS] * 8, {"from": alice})
+
+    reward = coin_reward.balanceOf(rewards_only_gauge)
+    assert reward <= REWARD
+    assert approx(REWARD, reward, 1.001 / WEEK)
+
+
+def test_modify_no_deposit_no_ts(reward_contract_2, alice, rewards_only_gauge, coin_a):
+    sigs = f"0x{'00' * 4}{'00' * 4}{reward_contract_2.getReward.signature[2:]}{'00' * 20}"
+    rewards_only_gauge.set_rewards(
+        reward_contract_2, sigs, [coin_a] + [ZERO_ADDRESS] * 7, {"from": alice}
+    )
+
+    assert rewards_only_gauge.reward_contract() == reward_contract_2
+    assert rewards_only_gauge.reward_tokens(0) == coin_a
+    assert rewards_only_gauge.reward_tokens(1) == ZERO_ADDRESS
+
+
+def test_modify_no_deposit(
+    reward_contract,
+    reward_contract_2,
+    alice,
+    rewards_only_gauge,
+    chain,
+    coin_a,
+    coin_reward,
+    mock_lp_token,
+):
+    rewards_only_gauge.deposit(LP_AMOUNT, {"from": alice})
+    coin_reward._mint_for_testing(REWARD, {"from": reward_contract})
+    reward_contract.notifyRewardAmount(REWARD, {"from": alice})
+    chain.sleep(86400)
+
+    sigs = f"0x{'00' * 4}{'00' * 4}{reward_contract_2.getReward.signature[2:]}{'00' * 20}"
+    rewards_only_gauge.set_rewards(
+        reward_contract_2, sigs, [coin_a] + [ZERO_ADDRESS] * 7, {"from": alice}
+    )
+
+    assert mock_lp_token.balanceOf(rewards_only_gauge) == LP_AMOUNT
+    assert rewards_only_gauge.reward_contract() == reward_contract_2
+    assert rewards_only_gauge.reward_tokens(0) == coin_a
+    assert rewards_only_gauge.reward_tokens(1) == ZERO_ADDRESS
+    assert coin_reward.balanceOf(rewards_only_gauge) > 0
+
+
+def test_modify_deposit(
+    reward_contract,
+    reward_contract_2,
+    alice,
+    rewards_only_gauge,
+    chain,
+    coin_a,
+    coin_reward,
+    mock_lp_token,
+):
+    rewards_only_gauge.deposit(LP_AMOUNT, {"from": alice})
+    coin_reward._mint_for_testing(REWARD, {"from": reward_contract})
+    reward_contract.notifyRewardAmount(REWARD, {"from": alice})
+    chain.sleep(86400)
+
+    sigs = [
+        reward_contract.stake.signature[2:],
+        reward_contract.withdraw.signature[2:],
+        reward_contract.getReward.signature[2:],
+    ]
+    sigs = f"0x{sigs[0]}{sigs[1]}{sigs[2]}{'00' * 20}"
+    rewards_only_gauge.set_rewards(
+        reward_contract_2, sigs, [coin_a] + [ZERO_ADDRESS] * 7, {"from": alice}
+    )
+
+    assert mock_lp_token.balanceOf(reward_contract_2) == LP_AMOUNT
+    assert rewards_only_gauge.reward_contract() == reward_contract_2
+    assert rewards_only_gauge.reward_tokens(0) == coin_a
+    assert rewards_only_gauge.reward_tokens(1) == ZERO_ADDRESS
+    assert coin_reward.balanceOf(rewards_only_gauge) > 0
+
+
+def test_modify_deposit_no_ts(reward_contract_2, alice, rewards_only_gauge, coin_a):
+    sigs = [
+        reward_contract_2.stake.signature[2:],
+        reward_contract_2.withdraw.signature[2:],
+        reward_contract_2.getReward.signature[2:],
+    ]
+    sigs = f"0x{sigs[0]}{sigs[1]}{sigs[2]}{'00' * 20}"
+    with brownie.reverts("dev: zero total supply"):
+        rewards_only_gauge.set_rewards(
+            reward_contract_2, sigs, [coin_a] + [ZERO_ADDRESS] * 7, {"from": alice}
+        )

--- a/tests/unitary/RewardsOnlyGauge/test_set_rewards_no_deposit.py
+++ b/tests/unitary/RewardsOnlyGauge/test_set_rewards_no_deposit.py
@@ -1,0 +1,128 @@
+import brownie
+import pytest
+from brownie import ZERO_ADDRESS
+
+REWARD = 10 ** 20
+WEEK = 7 * 86400
+LP_AMOUNT = 10 ** 18
+
+
+@pytest.fixture(scope="module")
+def reward_contract_2(CurveRewards, mock_lp_token, accounts, coin_a):
+    contract = CurveRewards.deploy(mock_lp_token, coin_a, {"from": accounts[0]})
+    contract.setRewardDistribution(accounts[0], {"from": accounts[0]})
+    yield contract
+
+
+@pytest.fixture(scope="module", autouse=True)
+def initial_setup(rewards_only_gauge, mock_lp_token, alice, reward_contract, coin_reward):
+    mock_lp_token.approve(rewards_only_gauge, LP_AMOUNT, {"from": alice})
+    sigs = f"0x{'00' * 4}{'00' * 4}{reward_contract.getReward.signature[2:]}{'00' * 20}"
+    rewards_only_gauge.set_rewards(
+        reward_contract, sigs, [coin_reward] + [ZERO_ADDRESS] * 7, {"from": alice}
+    )
+
+
+def test_unset_no_totalsupply(
+    alice, coin_reward, reward_contract, rewards_only_gauge, mock_lp_token
+):
+    rewards_only_gauge.set_rewards(ZERO_ADDRESS, "0x00", [ZERO_ADDRESS] * 8, {"from": alice})
+
+    assert mock_lp_token.allowance(rewards_only_gauge, reward_contract) == 0
+    assert rewards_only_gauge.reward_contract() == ZERO_ADDRESS
+    assert [rewards_only_gauge.reward_tokens(i) for i in range(8)] == [ZERO_ADDRESS] * 8
+
+
+def test_unset_with_totalsupply(
+    alice, coin_reward, reward_contract, rewards_only_gauge, mock_lp_token
+):
+    rewards_only_gauge.deposit(LP_AMOUNT, {"from": alice})
+    rewards_only_gauge.set_rewards(ZERO_ADDRESS, "0x00", [ZERO_ADDRESS] * 8, {"from": alice})
+
+    assert mock_lp_token.allowance(rewards_only_gauge, reward_contract) == 0
+    assert mock_lp_token.balanceOf(rewards_only_gauge) == LP_AMOUNT
+    assert rewards_only_gauge.reward_contract() == ZERO_ADDRESS
+    assert [rewards_only_gauge.reward_tokens(i) for i in range(8)] == [ZERO_ADDRESS] * 8
+
+
+def test_modify_no_deposit_no_ts(
+    reward_contract_2, alice, rewards_only_gauge, coin_a, mock_lp_token
+):
+    sigs = f"0x{'00' * 4}{'00' * 4}{reward_contract_2.getReward.signature[2:]}{'00' * 20}"
+    rewards_only_gauge.set_rewards(
+        reward_contract_2, sigs, [coin_a] + [ZERO_ADDRESS] * 7, {"from": alice}
+    )
+
+    assert rewards_only_gauge.reward_contract() == reward_contract_2
+    assert rewards_only_gauge.reward_tokens(0) == coin_a
+    assert rewards_only_gauge.reward_tokens(1) == ZERO_ADDRESS
+
+
+def test_modify_no_deposit(
+    reward_contract,
+    reward_contract_2,
+    alice,
+    rewards_only_gauge,
+    chain,
+    coin_a,
+    coin_reward,
+    mock_lp_token,
+):
+    rewards_only_gauge.deposit(LP_AMOUNT, {"from": alice})
+    coin_reward._mint_for_testing(REWARD, {"from": reward_contract})
+    reward_contract.notifyRewardAmount(REWARD, {"from": alice})
+    chain.sleep(86400)
+
+    sigs = f"0x{'00' * 4}{'00' * 4}{reward_contract_2.getReward.signature[2:]}{'00' * 20}"
+    rewards_only_gauge.set_rewards(
+        reward_contract_2, sigs, [coin_a] + [ZERO_ADDRESS] * 7, {"from": alice}
+    )
+
+    assert mock_lp_token.balanceOf(rewards_only_gauge) == LP_AMOUNT
+    assert rewards_only_gauge.reward_contract() == reward_contract_2
+    assert rewards_only_gauge.reward_tokens(0) == coin_a
+    assert rewards_only_gauge.reward_tokens(1) == ZERO_ADDRESS
+
+
+def test_modify_deposit(
+    reward_contract,
+    reward_contract_2,
+    alice,
+    rewards_only_gauge,
+    chain,
+    coin_a,
+    coin_reward,
+    mock_lp_token,
+):
+    rewards_only_gauge.deposit(LP_AMOUNT, {"from": alice})
+    coin_reward._mint_for_testing(REWARD, {"from": reward_contract})
+    reward_contract.notifyRewardAmount(REWARD, {"from": alice})
+    chain.sleep(86400)
+
+    sigs = [
+        reward_contract.stake.signature[2:],
+        reward_contract.withdraw.signature[2:],
+        reward_contract.getReward.signature[2:],
+    ]
+    sigs = f"0x{sigs[0]}{sigs[1]}{sigs[2]}{'00' * 20}"
+    rewards_only_gauge.set_rewards(
+        reward_contract_2, sigs, [coin_a] + [ZERO_ADDRESS] * 7, {"from": alice}
+    )
+
+    assert mock_lp_token.balanceOf(reward_contract_2) == LP_AMOUNT
+    assert rewards_only_gauge.reward_contract() == reward_contract_2
+    assert rewards_only_gauge.reward_tokens(0) == coin_a
+    assert rewards_only_gauge.reward_tokens(1) == ZERO_ADDRESS
+
+
+def test_modify_deposit_no_ts(reward_contract_2, alice, rewards_only_gauge, coin_a):
+    sigs = [
+        reward_contract_2.stake.signature[2:],
+        reward_contract_2.withdraw.signature[2:],
+        reward_contract_2.getReward.signature[2:],
+    ]
+    sigs = f"0x{sigs[0]}{sigs[1]}{sigs[2]}{'00' * 20}"
+    with brownie.reverts("dev: zero total supply"):
+        rewards_only_gauge.set_rewards(
+            reward_contract_2, sigs, [coin_a] + [ZERO_ADDRESS] * 7, {"from": alice}
+        )

--- a/tests/unitary/RewardsOnlyGauge/test_transfer.py
+++ b/tests/unitary/RewardsOnlyGauge/test_transfer.py
@@ -1,0 +1,91 @@
+#!/usr/bin/python3
+import brownie
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup(accounts, gauge_controller, minter, rewards_only_gauge, token, mock_lp_token):
+    token.set_minter(minter, {"from": accounts[0]})
+
+    gauge_controller.add_type(b"Liquidity", 10 ** 10, {"from": accounts[0]})
+    gauge_controller.add_gauge(rewards_only_gauge, 0, 0, {"from": accounts[0]})
+
+    mock_lp_token.approve(rewards_only_gauge, 2 ** 256 - 1, {"from": accounts[0]})
+    rewards_only_gauge.deposit(10 ** 18, {"from": accounts[0]})
+
+
+def test_sender_balance_decreases(accounts, rewards_only_gauge):
+    sender_balance = rewards_only_gauge.balanceOf(accounts[0])
+    amount = sender_balance // 4
+
+    rewards_only_gauge.transfer(accounts[1], amount, {"from": accounts[0]})
+
+    assert rewards_only_gauge.balanceOf(accounts[0]) == sender_balance - amount
+
+
+def test_receiver_balance_increases(accounts, rewards_only_gauge):
+    receiver_balance = rewards_only_gauge.balanceOf(accounts[1])
+    amount = rewards_only_gauge.balanceOf(accounts[0]) // 4
+
+    rewards_only_gauge.transfer(accounts[1], amount, {"from": accounts[0]})
+
+    assert rewards_only_gauge.balanceOf(accounts[1]) == receiver_balance + amount
+
+
+def test_total_supply_not_affected(accounts, rewards_only_gauge):
+    total_supply = rewards_only_gauge.totalSupply()
+    amount = rewards_only_gauge.balanceOf(accounts[0])
+
+    rewards_only_gauge.transfer(accounts[1], amount, {"from": accounts[0]})
+
+    assert rewards_only_gauge.totalSupply() == total_supply
+
+
+def test_returns_true(accounts, rewards_only_gauge):
+    amount = rewards_only_gauge.balanceOf(accounts[0])
+    tx = rewards_only_gauge.transfer(accounts[1], amount, {"from": accounts[0]})
+
+    assert tx.return_value is True
+
+
+def test_transfer_full_balance(accounts, rewards_only_gauge):
+    amount = rewards_only_gauge.balanceOf(accounts[0])
+    receiver_balance = rewards_only_gauge.balanceOf(accounts[1])
+
+    rewards_only_gauge.transfer(accounts[1], amount, {"from": accounts[0]})
+
+    assert rewards_only_gauge.balanceOf(accounts[0]) == 0
+    assert rewards_only_gauge.balanceOf(accounts[1]) == receiver_balance + amount
+
+
+def test_transfer_zero_tokens(accounts, rewards_only_gauge):
+    sender_balance = rewards_only_gauge.balanceOf(accounts[0])
+    receiver_balance = rewards_only_gauge.balanceOf(accounts[1])
+
+    rewards_only_gauge.transfer(accounts[1], 0, {"from": accounts[0]})
+
+    assert rewards_only_gauge.balanceOf(accounts[0]) == sender_balance
+    assert rewards_only_gauge.balanceOf(accounts[1]) == receiver_balance
+
+
+def test_transfer_to_self(accounts, rewards_only_gauge):
+    sender_balance = rewards_only_gauge.balanceOf(accounts[0])
+    amount = sender_balance // 4
+
+    rewards_only_gauge.transfer(accounts[0], amount, {"from": accounts[0]})
+
+    assert rewards_only_gauge.balanceOf(accounts[0]) == sender_balance
+
+
+def test_insufficient_balance(accounts, rewards_only_gauge):
+    balance = rewards_only_gauge.balanceOf(accounts[0])
+
+    with brownie.reverts():
+        rewards_only_gauge.transfer(accounts[1], balance + 1, {"from": accounts[0]})
+
+
+def test_transfer_event_fires(accounts, rewards_only_gauge):
+    amount = rewards_only_gauge.balanceOf(accounts[0])
+    tx = rewards_only_gauge.transfer(accounts[1], amount, {"from": accounts[0]})
+
+    assert tx.events["Transfer"].values() == [accounts[0], accounts[1], amount]

--- a/tests/unitary/RewardsOnlyGauge/test_transferFrom.py
+++ b/tests/unitary/RewardsOnlyGauge/test_transferFrom.py
@@ -1,0 +1,190 @@
+#!/usr/bin/python3
+import brownie
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup(accounts, gauge_controller, minter, rewards_only_gauge, token, mock_lp_token):
+    token.set_minter(minter, {"from": accounts[0]})
+
+    gauge_controller.add_type(b"Liquidity", 10 ** 10, {"from": accounts[0]})
+    gauge_controller.add_gauge(rewards_only_gauge, 0, 0, {"from": accounts[0]})
+
+    mock_lp_token.approve(rewards_only_gauge, 2 ** 256 - 1, {"from": accounts[0]})
+    rewards_only_gauge.deposit(10 ** 18, {"from": accounts[0]})
+
+
+def test_sender_balance_decreases(accounts, rewards_only_gauge):
+    sender_balance = rewards_only_gauge.balanceOf(accounts[0])
+    amount = sender_balance // 4
+
+    rewards_only_gauge.approve(accounts[1], amount, {"from": accounts[0]})
+    rewards_only_gauge.transferFrom(accounts[0], accounts[2], amount, {"from": accounts[1]})
+
+    assert rewards_only_gauge.balanceOf(accounts[0]) == sender_balance - amount
+
+
+def test_receiver_balance_increases(accounts, rewards_only_gauge):
+    receiver_balance = rewards_only_gauge.balanceOf(accounts[2])
+    amount = rewards_only_gauge.balanceOf(accounts[0]) // 4
+
+    rewards_only_gauge.approve(accounts[1], amount, {"from": accounts[0]})
+    rewards_only_gauge.transferFrom(accounts[0], accounts[2], amount, {"from": accounts[1]})
+
+    assert rewards_only_gauge.balanceOf(accounts[2]) == receiver_balance + amount
+
+
+def test_caller_balance_not_affected(accounts, rewards_only_gauge):
+    caller_balance = rewards_only_gauge.balanceOf(accounts[1])
+    amount = rewards_only_gauge.balanceOf(accounts[0])
+
+    rewards_only_gauge.approve(accounts[1], amount, {"from": accounts[0]})
+    rewards_only_gauge.transferFrom(accounts[0], accounts[2], amount, {"from": accounts[1]})
+
+    assert rewards_only_gauge.balanceOf(accounts[1]) == caller_balance
+
+
+def test_caller_approval_affected(accounts, rewards_only_gauge):
+    approval_amount = rewards_only_gauge.balanceOf(accounts[0])
+    transfer_amount = approval_amount // 4
+
+    rewards_only_gauge.approve(accounts[1], approval_amount, {"from": accounts[0]})
+    rewards_only_gauge.transferFrom(
+        accounts[0], accounts[2], transfer_amount, {"from": accounts[1]}
+    )
+
+    assert (
+        rewards_only_gauge.allowance(accounts[0], accounts[1]) == approval_amount - transfer_amount
+    )
+
+
+def test_receiver_approval_not_affected(accounts, rewards_only_gauge):
+    approval_amount = rewards_only_gauge.balanceOf(accounts[0])
+    transfer_amount = approval_amount // 4
+
+    rewards_only_gauge.approve(accounts[1], approval_amount, {"from": accounts[0]})
+    rewards_only_gauge.approve(accounts[2], approval_amount, {"from": accounts[0]})
+    rewards_only_gauge.transferFrom(
+        accounts[0], accounts[2], transfer_amount, {"from": accounts[1]}
+    )
+
+    assert rewards_only_gauge.allowance(accounts[0], accounts[2]) == approval_amount
+
+
+def test_total_supply_not_affected(accounts, rewards_only_gauge):
+    total_supply = rewards_only_gauge.totalSupply()
+    amount = rewards_only_gauge.balanceOf(accounts[0])
+
+    rewards_only_gauge.approve(accounts[1], amount, {"from": accounts[0]})
+    rewards_only_gauge.transferFrom(accounts[0], accounts[2], amount, {"from": accounts[1]})
+
+    assert rewards_only_gauge.totalSupply() == total_supply
+
+
+def test_returns_true(accounts, rewards_only_gauge):
+    amount = rewards_only_gauge.balanceOf(accounts[0])
+    rewards_only_gauge.approve(accounts[1], amount, {"from": accounts[0]})
+    tx = rewards_only_gauge.transferFrom(accounts[0], accounts[2], amount, {"from": accounts[1]})
+
+    assert tx.return_value is True
+
+
+def test_transfer_full_balance(accounts, rewards_only_gauge):
+    amount = rewards_only_gauge.balanceOf(accounts[0])
+    receiver_balance = rewards_only_gauge.balanceOf(accounts[2])
+
+    rewards_only_gauge.approve(accounts[1], amount, {"from": accounts[0]})
+    rewards_only_gauge.transferFrom(accounts[0], accounts[2], amount, {"from": accounts[1]})
+
+    assert rewards_only_gauge.balanceOf(accounts[0]) == 0
+    assert rewards_only_gauge.balanceOf(accounts[2]) == receiver_balance + amount
+
+
+def test_transfer_zero_tokens(accounts, rewards_only_gauge):
+    sender_balance = rewards_only_gauge.balanceOf(accounts[0])
+    receiver_balance = rewards_only_gauge.balanceOf(accounts[2])
+
+    rewards_only_gauge.approve(accounts[1], sender_balance, {"from": accounts[0]})
+    rewards_only_gauge.transferFrom(accounts[0], accounts[2], 0, {"from": accounts[1]})
+
+    assert rewards_only_gauge.balanceOf(accounts[0]) == sender_balance
+    assert rewards_only_gauge.balanceOf(accounts[2]) == receiver_balance
+
+
+def test_transfer_zero_tokens_without_approval(accounts, rewards_only_gauge):
+    sender_balance = rewards_only_gauge.balanceOf(accounts[0])
+    receiver_balance = rewards_only_gauge.balanceOf(accounts[2])
+
+    rewards_only_gauge.transferFrom(accounts[0], accounts[2], 0, {"from": accounts[1]})
+
+    assert rewards_only_gauge.balanceOf(accounts[0]) == sender_balance
+    assert rewards_only_gauge.balanceOf(accounts[2]) == receiver_balance
+
+
+def test_insufficient_balance(accounts, rewards_only_gauge):
+    balance = rewards_only_gauge.balanceOf(accounts[0])
+
+    rewards_only_gauge.approve(accounts[1], balance + 1, {"from": accounts[0]})
+    with brownie.reverts():
+        rewards_only_gauge.transferFrom(
+            accounts[0], accounts[2], balance + 1, {"from": accounts[1]}
+        )
+
+
+def test_insufficient_approval(accounts, rewards_only_gauge):
+    balance = rewards_only_gauge.balanceOf(accounts[0])
+
+    rewards_only_gauge.approve(accounts[1], balance - 1, {"from": accounts[0]})
+    with brownie.reverts():
+        rewards_only_gauge.transferFrom(accounts[0], accounts[2], balance, {"from": accounts[1]})
+
+
+def test_no_approval(accounts, rewards_only_gauge):
+    balance = rewards_only_gauge.balanceOf(accounts[0])
+
+    with brownie.reverts():
+        rewards_only_gauge.transferFrom(accounts[0], accounts[2], balance, {"from": accounts[1]})
+
+
+def test_infinite_approval(accounts, rewards_only_gauge):
+    rewards_only_gauge.approve(accounts[1], 2 ** 256 - 1, {"from": accounts[0]})
+    rewards_only_gauge.transferFrom(accounts[0], accounts[2], 10000, {"from": accounts[1]})
+
+    assert rewards_only_gauge.allowance(accounts[0], accounts[1]) == 2 ** 256 - 1
+
+
+def test_revoked_approval(accounts, rewards_only_gauge):
+    balance = rewards_only_gauge.balanceOf(accounts[0])
+
+    rewards_only_gauge.approve(accounts[1], balance, {"from": accounts[0]})
+    rewards_only_gauge.approve(accounts[1], 0, {"from": accounts[0]})
+
+    with brownie.reverts():
+        rewards_only_gauge.transferFrom(accounts[0], accounts[2], balance, {"from": accounts[1]})
+
+
+def test_transfer_to_self(accounts, rewards_only_gauge):
+    sender_balance = rewards_only_gauge.balanceOf(accounts[0])
+    amount = sender_balance // 4
+
+    rewards_only_gauge.approve(accounts[0], sender_balance, {"from": accounts[0]})
+    rewards_only_gauge.transferFrom(accounts[0], accounts[0], amount, {"from": accounts[0]})
+
+    assert rewards_only_gauge.balanceOf(accounts[0]) == sender_balance
+    assert rewards_only_gauge.allowance(accounts[0], accounts[0]) == sender_balance - amount
+
+
+def test_transfer_to_self_no_approval(accounts, rewards_only_gauge):
+    amount = rewards_only_gauge.balanceOf(accounts[0])
+
+    with brownie.reverts():
+        rewards_only_gauge.transferFrom(accounts[0], accounts[0], amount, {"from": accounts[0]})
+
+
+def test_transfer_event_fires(accounts, rewards_only_gauge):
+    amount = rewards_only_gauge.balanceOf(accounts[0])
+
+    rewards_only_gauge.approve(accounts[1], amount, {"from": accounts[0]})
+    tx = rewards_only_gauge.transferFrom(accounts[0], accounts[2], amount, {"from": accounts[1]})
+
+    assert tx.events["Transfer"].values() == [accounts[0], accounts[2], amount]


### PR DESCRIPTION
### What I did
Modify `LiquidityGaugeV2` to create a gauge that issues __only__ third-party rewards.  This is useful for incentivizing pools on sidechains, where the gauge controller and CRV minter are unavailable.

Most of the added test cases were copied/adapted from tests for `LiquidityGaugeV2`.  I have added new tests around a unique behavior for this gauge - the ability to handle rewards that are directly transferred in, without requiring an explicit claim action.