### PR TITLE
Fix flaky minter test

### DIFF
--- a/tests/unitary/Minter/test_minter.py
+++ b/tests/unitary/Minter/test_minter.py
@@ -12,8 +12,11 @@ WEEK = 7 * 86400
 
 
 @pytest.fixture(scope="module", autouse=True)
-def minter_setup(accounts, mock_lp_token, token, minter, gauge_controller, three_gauges):
+def minter_setup(accounts, mock_lp_token, token, minter, gauge_controller, three_gauges, chain):
     token.set_minter(minter, {"from": accounts[0]})
+
+    # ensure the tests all begin at the start of the epoch week
+    chain.mine(timestamp=(chain.time() / WEEK + 1) * WEEK)
 
     # set types
     for weight in TYPE_WEIGHTS:


### PR DESCRIPTION
One of the minter tests was failing for one day of every week.  The issue is in the test, not the smart contract, and I've been ignoring it for months now - finally it became too annoying.