### PR TITLE
Fix/child streamer

### DIFF
--- a/contracts/gauges/sidechain/ChildChainStreamer.vy
+++ b/contracts/gauges/sidechain/ChildChainStreamer.vy
@@ -120,10 +120,8 @@ def set_receiver(_receiver: address):
 @external
 def get_reward():
     """
-    @notice Claim pending rewards
-    @dev Only callable by the reward receiver
+    @notice Claim pending rewards for `reward_receiver`
     """
-    assert msg.sender == self.reward_receiver, "Caller is not receiver"
     last_update: uint256 = self.last_update_time
     for token in self.reward_tokens:
         if token == ZERO_ADDRESS:

--- a/tests/unitary/Sidechain/child_chain_streamer/test_get_reward.py
+++ b/tests/unitary/Sidechain/child_chain_streamer/test_get_reward.py
@@ -1,6 +1,5 @@
 import math
 
-import brownie
 import pytest
 
 DAY = 86400
@@ -15,9 +14,9 @@ def local_setup(alice, bob, charlie, coin_reward, child_chain_streamer):
     child_chain_streamer.notify_reward_amount(coin_reward, {"from": charlie})
 
 
-def test_receiver_only(alice, child_chain_streamer):
-    with brownie.reverts("Caller is not receiver"):
-        child_chain_streamer.get_reward({"from": alice})
+@pytest.mark.parametrize("idx", range(5))
+def test_unguarded(accounts, child_chain_streamer, idx):
+    child_chain_streamer.get_reward({"from": accounts[idx]})
 
 
 def test_last_update_time(bob, chain, child_chain_streamer):

--- a/tests/unitary/Sidechain/child_chain_streamer/test_notify_reward_amount.py
+++ b/tests/unitary/Sidechain/child_chain_streamer/test_notify_reward_amount.py
@@ -15,22 +15,19 @@ def local_setup(alice, bob, charlie, chain, coin_reward, child_chain_streamer):
     child_chain_streamer.set_receiver(bob, {"from": alice})
 
 
-def test_only_distributor(alice, charlie, coin_reward, child_chain_streamer):
-    with brownie.reverts("dev: only distributor"):
-        child_chain_streamer.notify_reward_amount(coin_reward, {"from": alice})
-
-    child_chain_streamer.notify_reward_amount(coin_reward, {"from": charlie})
+@pytest.mark.parametrize("idx", range(5))
+def test_unguarded(accounts, coin_reward, child_chain_streamer, idx):
+    child_chain_streamer.notify_reward_amount(coin_reward, {"from": accounts[idx]})
 
 
-def test_available_rewards_are_distributed(charlie, bob, chain, coin_reward, child_chain_streamer):
+def test_only_updates(charlie, bob, chain, coin_reward, child_chain_streamer):
 
     child_chain_streamer.notify_reward_amount(coin_reward, {"from": charlie})
 
     chain.mine(timedelta=DAY * 7)
 
-    child_chain_streamer.notify_reward_amount(coin_reward, {"from": charlie})
-
-    assert math.isclose(coin_reward.balanceOf(bob), 50 * 10 ** 18, rel_tol=0.00001)
+    with brownie.reverts("Invalid token or no new reward"):
+        child_chain_streamer.notify_reward_amount(coin_reward, {"from": charlie})
 
 
 def test_increase_reward_amount_mid_distribution(
@@ -50,3 +47,21 @@ def test_increase_reward_amount_mid_distribution(
     assert data["period_finish"] == tx.timestamp + 14 * DAY
     assert data["received"] == 200 * 10 ** 18
     assert math.isclose(data["rate"], expected_rate, rel_tol=0.00001)
+
+
+def test_mid_distribution_only_distributor(
+    alice, charlie, bob, chain, coin_reward, child_chain_streamer
+):
+    # Verify that mid distribution of rewards, only the distributor can call
+    # notify_reward_amount again, otherwise the period will be extended by a
+    # bad actor
+    child_chain_streamer.notify_reward_amount(coin_reward, {"from": charlie})
+
+    chain.mine(timedelta=DAY * 7)
+
+    # bob gets tokens, then sends them to the streamer hoping to call `notify_reward_amount`
+    coin_reward._mint_for_testing(100 * 10 ** 18, {"from": bob})
+    coin_reward.transfer(child_chain_streamer, 100 * 10 ** 18, {"from": bob})
+
+    with brownie.reverts("Reward period still active"):
+        child_chain_streamer.notify_reward_amount(coin_reward, {"from": bob})


### PR DESCRIPTION
### What I did
Allow for unguarded calls to `ChildChainStreamer.notify_reward_amount` under specific conditions.

Removing admin powers is good.