### PR TITLE
RootChainGauge fixes and testing

### DIFF
--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -6,7 +6,6 @@ networks:
   development:
     cmd_settings:
       accounts: 100
-      time: 2021-05-12T21:52:33.856164
   mainnet-fork:
     cmd_settings:
       unlock: 0xC447FcAF1dEf19A583F97b3620627BF69c05b5fB

--- a/contracts/gauges/sidechain/RootGaugeAnyswap.vy
+++ b/contracts/gauges/sidechain/RootGaugeAnyswap.vy
@@ -85,7 +85,7 @@ def __init__(_minter: address, _admin: address, _anyswap_bridge: address):
     assert rate != 0
     self.inflation_rate = rate
 
-    self.period = block.timestamp / WEEK
+    self.period = block.timestamp / WEEK - 1
     self.start_epoch_time = CRV20(crv_token).start_epoch_time_write()
 
 
@@ -97,7 +97,7 @@ def checkpoint() -> bool:
     """
     assert self.checkpoint_admin in [ZERO_ADDRESS, msg.sender]
     last_period: uint256 = self.period
-    current_period: uint256 = block.timestamp / WEEK
+    current_period: uint256 = block.timestamp / WEEK - 1
 
     if last_period < current_period:
         controller: address = self.controller

--- a/contracts/gauges/sidechain/RootGaugeAnyswap.vy
+++ b/contracts/gauges/sidechain/RootGaugeAnyswap.vy
@@ -11,15 +11,12 @@ from vyper.interfaces import ERC20
 
 
 interface CRV20:
-    def future_epoch_time_write() -> uint256: nonpayable
+    def start_epoch_time_write() -> uint256: nonpayable
     def rate() -> uint256: view
 
 interface Controller:
     def period() -> int128: view
-    def period_write() -> int128: nonpayable
-    def period_timestamp(p: int128) -> uint256: view
     def gauge_relative_weight(addr: address, time: uint256) -> uint256: view
-    def voting_escrow() -> address: view
     def checkpoint(): nonpayable
     def checkpoint_gauge(addr: address): nonpayable
 
@@ -30,44 +27,24 @@ interface Minter:
     def mint(gauge: address): nonpayable
 
 
-event Deposit:
-    provider: indexed(address)
-    value: uint256
-
-event Withdraw:
-    provider: indexed(address)
-    value: uint256
-
-event UpdateLiquidityLimit:
-    user: address
-    original_balance: uint256
-    original_supply: uint256
-    working_balance: uint256
-    working_supply: uint256
-
 event CommitOwnership:
     admin: address
 
 event ApplyOwnership:
     admin: address
 
-event Transfer:
-    _from: indexed(address)
-    _to: indexed(address)
-    _value: uint256
-
-event Approval:
-    _owner: indexed(address)
-    _spender: indexed(address)
-    _value: uint256
-
 
 WEEK: constant(uint256) = 604800
+YEAR: constant(uint256) = 86400 * 365
+RATE_DENOMINATOR: constant(uint256) = 10 ** 18
+RATE_REDUCTION_COEFFICIENT: constant(uint256) = 1189207115002721024  # 2 ** (1/4) * 1e18
+RATE_REDUCTION_TIME: constant(uint256) = YEAR
+
 
 minter: public(address)
 crv_token: public(address)
 controller: public(address)
-future_epoch_time: public(uint256)
+start_epoch_time: public(uint256)
 
 period: public(uint256)
 emissions: public(uint256)
@@ -91,18 +68,21 @@ def __init__(_minter: address, _admin: address, _anyswap_bridge: address):
     """
 
     crv_token: address = Minter(_minter).token()
-    controller: address = Minter(_minter).controller()
 
     self.minter = _minter
     self.admin = _admin
     self.crv_token = crv_token
-    self.controller = controller
+    self.controller = Minter(_minter).controller()
     self.anyswap_bridge = _anyswap_bridge
 
-    self.period = block.timestamp / WEEK
-    self.inflation_rate = CRV20(crv_token).rate()
-    self.future_epoch_time = CRV20(crv_token).future_epoch_time_write()
+    # because we calculate the rate locally, this gauge cannot
+    # be used prior to the start of the first emission period
+    rate: uint256 = CRV20(crv_token).rate()
+    assert rate != 0
+    self.inflation_rate = rate
 
+    self.period = block.timestamp / WEEK
+    self.start_epoch_time = CRV20(crv_token).start_epoch_time_write()
 
 
 @external
@@ -112,15 +92,6 @@ def checkpoint() -> bool:
     @dev Should be called once per week, after the new epoch period has begun
     """
     assert self.checkpoint_admin in [ZERO_ADDRESS, msg.sender]
-    rate: uint256 = self.inflation_rate
-    new_rate: uint256 = rate
-    prev_future_epoch: uint256 = self.future_epoch_time
-    token: address = self.crv_token
-    if prev_future_epoch < block.timestamp:
-        self.future_epoch_time = CRV20(token).future_epoch_time_write()
-        new_rate = CRV20(token).rate()
-        self.inflation_rate = new_rate
-
     last_period: uint256 = self.period
     current_period: uint256 = block.timestamp / WEEK
 
@@ -128,31 +99,45 @@ def checkpoint() -> bool:
         controller: address = self.controller
         Controller(controller).checkpoint_gauge(self)
 
+        rate: uint256 = self.inflation_rate
         emissions: uint256 = 0
         last_period += 1
-        for i in range(last_period, last_period+255):
+        next_epoch_time: uint256 = self.start_epoch_time + RATE_REDUCTION_TIME
+        for i in range(last_period, last_period + 255):
             if i > current_period:
                 break
             week_time: uint256 = i * WEEK
             gauge_weight: uint256 = Controller(controller).gauge_relative_weight(self, i * WEEK)
-            emissions += gauge_weight * rate * WEEK / 10**18
 
-            if prev_future_epoch < week_time:
-                # If we went across one or multiple epochs, apply the rate
-                # of the first epoch until it ends, and then the rate of
-                # the last epoch.
-                # If more than one epoch is crossed - the gauge gets less,
-                # but that'd meen it wasn't called for more than 1 year
-                rate = new_rate
-                prev_future_epoch = MAX_UINT256
+            if next_epoch_time >= week_time and next_epoch_time < week_time + WEEK:
+                # If the period crosses an epoch, we calculate a reduction in the rate
+                # using the same formula as used in `ERC20CRV`. We perform the calculation
+                # locally instead of calling to `ERC20CRV.rate()` because we are generating
+                # the emissions for the upcoming week, so there is a possibility the new
+                # rate has not yet been applied.
+                emissions += gauge_weight * rate * (next_epoch_time - week_time) / 10**18
+                rate = rate * RATE_DENOMINATOR / RATE_REDUCTION_COEFFICIENT
+                emissions += gauge_weight * rate * (week_time + WEEK - next_epoch_time) / 10**18
+
+                self.inflation_rate = rate
+                self.start_epoch_time = next_epoch_time
+                next_epoch_time += RATE_REDUCTION_TIME
+            else:
+                emissions += gauge_weight * rate * WEEK / 10**18
 
         self.period = current_period
         self.emissions += emissions
         if emissions > 0 and not self.is_killed:
             Minter(self.minter).mint(self)
-            ERC20(token).transfer(self.anyswap_bridge, emissions)
+            ERC20(self.crv_token).transfer(self.anyswap_bridge, emissions)
 
     return True
+
+
+@view
+@external
+def future_epoch_time() -> uint256:
+    return self.start_epoch_time + YEAR
 
 
 @view

--- a/contracts/gauges/sidechain/RootGaugeAnyswap.vy
+++ b/contracts/gauges/sidechain/RootGaugeAnyswap.vy
@@ -27,6 +27,10 @@ interface Minter:
     def mint(gauge: address): nonpayable
 
 
+event PeriodEmission:
+    period_start: uint256
+    mint_amount: uint256
+
 event CommitOwnership:
     admin: address
 
@@ -100,36 +104,40 @@ def checkpoint() -> bool:
         Controller(controller).checkpoint_gauge(self)
 
         rate: uint256 = self.inflation_rate
-        emissions: uint256 = 0
+        new_emissions: uint256 = 0
         last_period += 1
         next_epoch_time: uint256 = self.start_epoch_time + RATE_REDUCTION_TIME
         for i in range(last_period, last_period + 255):
             if i > current_period:
                 break
-            week_time: uint256 = i * WEEK
+            period_time: uint256 = i * WEEK
+            period_emission: uint256 = 0
             gauge_weight: uint256 = Controller(controller).gauge_relative_weight(self, i * WEEK)
 
-            if next_epoch_time >= week_time and next_epoch_time < week_time + WEEK:
+            if next_epoch_time >= period_time and next_epoch_time < period_time + WEEK:
                 # If the period crosses an epoch, we calculate a reduction in the rate
                 # using the same formula as used in `ERC20CRV`. We perform the calculation
                 # locally instead of calling to `ERC20CRV.rate()` because we are generating
                 # the emissions for the upcoming week, so there is a possibility the new
                 # rate has not yet been applied.
-                emissions += gauge_weight * rate * (next_epoch_time - week_time) / 10**18
+                period_emission = gauge_weight * rate * (next_epoch_time - period_time) / 10**18
                 rate = rate * RATE_DENOMINATOR / RATE_REDUCTION_COEFFICIENT
-                emissions += gauge_weight * rate * (week_time + WEEK - next_epoch_time) / 10**18
+                period_emission += gauge_weight * rate * (period_time + WEEK - next_epoch_time) / 10**18
 
                 self.inflation_rate = rate
                 self.start_epoch_time = next_epoch_time
                 next_epoch_time += RATE_REDUCTION_TIME
             else:
-                emissions += gauge_weight * rate * WEEK / 10**18
+                period_emission = gauge_weight * rate * WEEK / 10**18
+
+            log PeriodEmission(period_time, period_emission)
+            new_emissions += period_emission
 
         self.period = current_period
-        self.emissions += emissions
-        if emissions > 0 and not self.is_killed:
+        self.emissions += new_emissions
+        if new_emissions > 0 and not self.is_killed:
             Minter(self.minter).mint(self)
-            ERC20(self.crv_token).transfer(self.anyswap_bridge, emissions)
+            ERC20(self.crv_token).transfer(self.anyswap_bridge, new_emissions)
 
     return True
 

--- a/contracts/gauges/sidechain/RootGaugePolygon.vy
+++ b/contracts/gauges/sidechain/RootGaugePolygon.vy
@@ -26,6 +26,10 @@ interface Minter:
     def mint(gauge: address): nonpayable
 
 
+event PeriodEmission:
+    period_start: uint256
+    mint_amount: uint256
+
 event CommitOwnership:
     admin: address
 
@@ -98,34 +102,38 @@ def checkpoint() -> bool:
         Controller(controller).checkpoint_gauge(self)
 
         rate: uint256 = self.inflation_rate
-        emissions: uint256 = 0
+        new_emissions: uint256 = 0
         last_period += 1
         next_epoch_time: uint256 = self.start_epoch_time + RATE_REDUCTION_TIME
         for i in range(last_period, last_period + 255):
             if i > current_period:
                 break
-            week_time: uint256 = i * WEEK
+            period_time: uint256 = i * WEEK
+            period_emission: uint256 = 0
             gauge_weight: uint256 = Controller(controller).gauge_relative_weight(self, i * WEEK)
 
-            if next_epoch_time >= week_time and next_epoch_time < week_time + WEEK:
+            if next_epoch_time >= period_time and next_epoch_time < period_time + WEEK:
                 # If the period crosses an epoch, we calculate a reduction in the rate
                 # using the same formula as used in `ERC20CRV`. We perform the calculation
                 # locally instead of calling to `ERC20CRV.rate()` because we are generating
                 # the emissions for the upcoming week, so there is a possibility the new
                 # rate has not yet been applied.
-                emissions += gauge_weight * rate * (next_epoch_time - week_time) / 10**18
+                period_emission = gauge_weight * rate * (next_epoch_time - period_time) / 10**18
                 rate = rate * RATE_DENOMINATOR / RATE_REDUCTION_COEFFICIENT
-                emissions += gauge_weight * rate * (week_time + WEEK - next_epoch_time) / 10**18
+                period_emission += gauge_weight * rate * (period_time + WEEK - next_epoch_time) / 10**18
 
                 self.inflation_rate = rate
                 self.start_epoch_time = next_epoch_time
                 next_epoch_time += RATE_REDUCTION_TIME
             else:
-                emissions += gauge_weight * rate * WEEK / 10**18
+                period_emission = gauge_weight * rate * WEEK / 10**18
+
+            log PeriodEmission(period_time, period_emission)
+            new_emissions += period_emission
 
         self.period = current_period
-        self.emissions += emissions
-        if emissions > 0 and not self.is_killed:
+        self.emissions += new_emissions
+        if new_emissions > 0 and not self.is_killed:
             Minter(self.minter).mint(self)
             raw_call(
                 POLYGON_BRIDGE_MANAGER,
@@ -135,7 +143,7 @@ def checkpoint() -> bool:
                     convert(self.crv_token, bytes32),
                     convert(96, bytes32),
                     convert(32, bytes32),
-                    convert(emissions, bytes32),
+                    convert(new_emissions, bytes32),
                 )
             )
     return True

--- a/contracts/gauges/sidechain/RootGaugePolygon.vy
+++ b/contracts/gauges/sidechain/RootGaugePolygon.vy
@@ -83,7 +83,7 @@ def __init__(_minter: address, _admin: address):
     assert rate != 0
     self.inflation_rate = rate
 
-    self.period = block.timestamp / WEEK
+    self.period = block.timestamp / WEEK - 1
     self.start_epoch_time = CRV20(crv_token).start_epoch_time_write()
 
     ERC20(crv_token).approve(POLYGON_BRIDGE_RECEIVER, MAX_UINT256)
@@ -97,7 +97,7 @@ def checkpoint() -> bool:
     """
     assert self.checkpoint_admin in [ZERO_ADDRESS, msg.sender]
     last_period: uint256 = self.period
-    current_period: uint256 = block.timestamp / WEEK
+    current_period: uint256 = block.timestamp / WEEK - 1
 
     if last_period < current_period:
         controller: address = self.controller

--- a/contracts/gauges/sidechain/RootGaugePolygon.vy
+++ b/contracts/gauges/sidechain/RootGaugePolygon.vy
@@ -86,6 +86,8 @@ def __init__(_minter: address, _admin: address):
     self.period = block.timestamp / WEEK
     self.start_epoch_time = CRV20(crv_token).start_epoch_time_write()
 
+    ERC20(crv_token).approve(POLYGON_BRIDGE_RECEIVER, MAX_UINT256)
+
 
 @external
 def checkpoint() -> bool:

--- a/contracts/gauges/sidechain/RootGaugeXdai.vy
+++ b/contracts/gauges/sidechain/RootGaugeXdai.vy
@@ -82,7 +82,7 @@ def __init__(_minter: address, _admin: address):
     assert rate != 0
     self.inflation_rate = rate
 
-    self.period = block.timestamp / WEEK
+    self.period = block.timestamp / WEEK - 1
     self.start_epoch_time = CRV20(crv_token).start_epoch_time_write()
 
     ERC20(crv_token).approve(XDAI_BRIDGE, MAX_UINT256)
@@ -96,7 +96,7 @@ def checkpoint() -> bool:
     """
     assert self.checkpoint_admin in [ZERO_ADDRESS, msg.sender]
     last_period: uint256 = self.period
-    current_period: uint256 = block.timestamp / WEEK
+    current_period: uint256 = block.timestamp / WEEK - 1
 
     if last_period < current_period:
         controller: address = self.controller

--- a/contracts/gauges/sidechain/RootGaugeXdai.vy
+++ b/contracts/gauges/sidechain/RootGaugeXdai.vy
@@ -11,15 +11,12 @@ from vyper.interfaces import ERC20
 
 
 interface CRV20:
-    def future_epoch_time_write() -> uint256: nonpayable
+    def start_epoch_time_write() -> uint256: nonpayable
     def rate() -> uint256: view
 
 interface Controller:
     def period() -> int128: view
-    def period_write() -> int128: nonpayable
-    def period_timestamp(p: int128) -> uint256: view
     def gauge_relative_weight(addr: address, time: uint256) -> uint256: view
-    def voting_escrow() -> address: view
     def checkpoint(): nonpayable
     def checkpoint_gauge(addr: address): nonpayable
 
@@ -30,46 +27,25 @@ interface Minter:
     def mint(gauge: address): nonpayable
 
 
-event Deposit:
-    provider: indexed(address)
-    value: uint256
-
-event Withdraw:
-    provider: indexed(address)
-    value: uint256
-
-event UpdateLiquidityLimit:
-    user: address
-    original_balance: uint256
-    original_supply: uint256
-    working_balance: uint256
-    working_supply: uint256
-
 event CommitOwnership:
     admin: address
 
 event ApplyOwnership:
     admin: address
 
-event Transfer:
-    _from: indexed(address)
-    _to: indexed(address)
-    _value: uint256
-
-event Approval:
-    _owner: indexed(address)
-    _spender: indexed(address)
-    _value: uint256
-
 
 WEEK: constant(uint256) = 604800
+YEAR: constant(uint256) = 86400 * 365
+RATE_DENOMINATOR: constant(uint256) = 10 ** 18
+RATE_REDUCTION_COEFFICIENT: constant(uint256) = 1189207115002721024  # 2 ** (1/4) * 1e18
+RATE_REDUCTION_TIME: constant(uint256) = YEAR
 XDAI_BRIDGE: constant(address) = 0x88ad09518695c6c3712AC10a214bE5109a655671
 
 
 minter: public(address)
 crv_token: public(address)
 controller: public(address)
-future_epoch_time: public(uint256)
+start_epoch_time: public(uint256)
 
 period: public(uint256)
 emissions: public(uint256)
@@ -90,18 +66,20 @@ def __init__(_minter: address, _admin: address):
     """
 
     crv_token: address = Minter(_minter).token()
-    controller: address = Minter(_minter).controller()
 
     self.minter = _minter
     self.admin = _admin
     self.crv_token = crv_token
-    self.controller = controller
+    self.controller = Minter(_minter).controller()
+
+    # because we calculate the rate locally, this gauge cannot
+    # be used prior to the start of the first emission period
+    rate: uint256 = CRV20(crv_token).rate()
+    assert rate != 0
+    self.inflation_rate = rate
 
     self.period = block.timestamp / WEEK
-    self.inflation_rate = CRV20(crv_token).rate()
-    self.future_epoch_time = CRV20(crv_token).future_epoch_time_write()
-
-    ERC20(crv_token).approve(XDAI_BRIDGE, MAX_UINT256)
+    self.start_epoch_time = CRV20(crv_token).start_epoch_time_write()
 
 
 @external
@@ -111,15 +89,6 @@ def checkpoint() -> bool:
     @dev Should be called once per week, after the new epoch period has begun
     """
     assert self.checkpoint_admin in [ZERO_ADDRESS, msg.sender]
-    rate: uint256 = self.inflation_rate
-    new_rate: uint256 = rate
-    prev_future_epoch: uint256 = self.future_epoch_time
-    token: address = self.crv_token
-    if prev_future_epoch < block.timestamp:
-        self.future_epoch_time = CRV20(token).future_epoch_time_write()
-        new_rate = CRV20(token).rate()
-        self.inflation_rate = new_rate
-
     last_period: uint256 = self.period
     current_period: uint256 = block.timestamp / WEEK
 
@@ -127,23 +96,31 @@ def checkpoint() -> bool:
         controller: address = self.controller
         Controller(controller).checkpoint_gauge(self)
 
+        rate: uint256 = self.inflation_rate
         emissions: uint256 = 0
         last_period += 1
-        for i in range(last_period, last_period+255):
+        next_epoch_time: uint256 = self.start_epoch_time + RATE_REDUCTION_TIME
+        for i in range(last_period, last_period + 255):
             if i > current_period:
                 break
             week_time: uint256 = i * WEEK
             gauge_weight: uint256 = Controller(controller).gauge_relative_weight(self, i * WEEK)
-            emissions += gauge_weight * rate * WEEK / 10**18
 
-            if prev_future_epoch < week_time:
-                # If we went across one or multiple epochs, apply the rate
-                # of the first epoch until it ends, and then the rate of
-                # the last epoch.
-                # If more than one epoch is crossed - the gauge gets less,
-                # but that'd meen it wasn't called for more than 1 year
-                rate = new_rate
-                prev_future_epoch = MAX_UINT256
+            if next_epoch_time >= week_time and next_epoch_time < week_time + WEEK:
+                # If the period crosses an epoch, we calculate a reduction in the rate
+                # using the same formula as used in `ERC20CRV`. We perform the calculation
+                # locally instead of calling to `ERC20CRV.rate()` because we are generating
+                # the emissions for the upcoming week, so there is a possibility the new
+                # rate has not yet been applied.
+                emissions += gauge_weight * rate * (next_epoch_time - week_time) / 10**18
+                rate = rate * RATE_DENOMINATOR / RATE_REDUCTION_COEFFICIENT
+                emissions += gauge_weight * rate * (week_time + WEEK - next_epoch_time) / 10**18
+
+                self.inflation_rate = rate
+                self.start_epoch_time = next_epoch_time
+                next_epoch_time += RATE_REDUCTION_TIME
+            else:
+                emissions += gauge_weight * rate * WEEK / 10**18
 
         self.period = current_period
         self.emissions += emissions
@@ -153,13 +130,19 @@ def checkpoint() -> bool:
                 XDAI_BRIDGE,
                 concat(
                     method_id("relayTokens(address,address,uint256)"),
-                    convert(token, bytes32),
+                    convert(self.crv_token, bytes32),
                     convert(self, bytes32),
                     convert(emissions, bytes32),
                 )
             )
 
     return True
+
+
+@view
+@external
+def future_epoch_time() -> uint256:
+    return self.start_epoch_time + YEAR
 
 
 @view

--- a/contracts/gauges/sidechain/RootGaugeXdai.vy
+++ b/contracts/gauges/sidechain/RootGaugeXdai.vy
@@ -85,6 +85,8 @@ def __init__(_minter: address, _admin: address):
     self.period = block.timestamp / WEEK
     self.start_epoch_time = CRV20(crv_token).start_epoch_time_write()
 
+    ERC20(crv_token).approve(XDAI_BRIDGE, MAX_UINT256)
+
 
 @external
 def checkpoint() -> bool:

--- a/tests/integration/ERC20CRV/test_mintable_in_timeframe.py
+++ b/tests/integration/ERC20CRV/test_mintable_in_timeframe.py
@@ -43,8 +43,7 @@ def test_random_range_year_one(token, chain, accounts, time1, time2):
 
 
 @given(
-    start=strategy("uint", max_value=YEAR * 6),
-    duration=strategy("uint", max_value=YEAR),
+    start=strategy("uint", max_value=YEAR * 6), duration=strategy("uint", max_value=YEAR),
 )
 def test_random_range_multiple_epochs(token, chain, accounts, start, duration):
     creation_time = token.start_epoch_time()

--- a/tests/integration/ERC20CRV/test_mintable_in_timeframe.py
+++ b/tests/integration/ERC20CRV/test_mintable_in_timeframe.py
@@ -43,7 +43,8 @@ def test_random_range_year_one(token, chain, accounts, time1, time2):
 
 
 @given(
-    start=strategy("uint", max_value=YEAR * 6), duration=strategy("uint", max_value=YEAR),
+    start=strategy("uint", max_value=YEAR * 6),
+    duration=strategy("uint", max_value=YEAR),
 )
 def test_random_range_multiple_epochs(token, chain, accounts, start, duration):
     creation_time = token.start_epoch_time()

--- a/tests/unitary/Sidechain/conftest.py
+++ b/tests/unitary/Sidechain/conftest.py
@@ -3,17 +3,24 @@ from brownie import ETH_ADDRESS
 
 
 @pytest.fixture(scope="module")
-def anyswap_root_gauge(RootGaugeAnyswap, minter, alice):
+def _root_gauge_setup(token, minter, chain, alice):
+    token.set_minter(minter, {"from": alice})
+    chain.mine(timedelta=604800)
+    token.update_mining_parameters({"from": alice})
+
+
+@pytest.fixture(scope="module")
+def anyswap_root_gauge(_root_gauge_setup, RootGaugeAnyswap, minter, alice):
     return RootGaugeAnyswap.deploy(minter, alice, ETH_ADDRESS, {"from": alice})
 
 
 @pytest.fixture(scope="module")
-def polygon_root_gauge(RootGaugePolygon, minter, alice):
+def polygon_root_gauge(_root_gauge_setup, RootGaugePolygon, minter, alice):
     return RootGaugePolygon.deploy(minter, alice, {"from": alice})
 
 
 @pytest.fixture(scope="module")
-def xdai_root_gauge(RootGaugeXdai, minter, alice):
+def xdai_root_gauge(_root_gauge_setup, RootGaugeXdai, minter, alice):
     return RootGaugeXdai.deploy(minter, alice, {"from": alice})
 
 

--- a/tests/unitary/Sidechain/test_root_checkpoint.py
+++ b/tests/unitary/Sidechain/test_root_checkpoint.py
@@ -77,17 +77,16 @@ def test_emissions_against_other_gauge(
     # sleep until the start of the next epoch week
     chain.mine(timestamp=(tx.timestamp // WEEK + 1) * WEEK)
 
-    last_week_claimable = 0
     # 110 weeks ensures we see 2 reductions in the rate
     for i in range(1, 110):
         # checkpointing the root gauge mints all the allocated emissions for the next week
         tx = root_gauge.checkpoint()
-        emissions = root_gauge.emissions()  # emissions this week are delayed by a week so
+        emissions = root_gauge.emissions()  # emissions this week are delayed y a week so
 
-        # now we time travel one week, and get the claimable rewards from the regular gauge
-        chain.mine(timestamp=(tx.timestamp // WEEK + 1) * WEEK)
         claimable = liquidity_gauge.claimable_tokens(alice, {"from": alice}).return_value
 
         # root gauge emissions should be equal to regular gauge claimable amount
-        assert math.isclose(emissions, last_week_claimable, rel_tol=1e-6)
-        last_week_claimable = claimable
+        assert math.isclose(emissions, claimable, rel_tol=1e-6)
+
+        # now we time travel one week, and get the claimable rewards from the regular gauge
+        chain.mine(timestamp=(tx.timestamp // WEEK + 1) * WEEK)

--- a/tests/unitary/Sidechain/test_root_checkpoint.py
+++ b/tests/unitary/Sidechain/test_root_checkpoint.py
@@ -1,41 +1,80 @@
 import math
 
 import pytest
+from brownie import chain
 
 WEEK = 7 * 86400
+YEAR = 365 * 86400
 
 
-@pytest.fixture(autouse=True)
-def local_setup(alice, chain, gauge_controller, liquidity_gauge, root_gauge, token, minter):
-    token.set_minter(minter, {"from": alice})
-    chain.mine(timedelta=WEEK)
-    token.update_mining_parameters({"from": alice})
-
+@pytest.mark.skip_coverage
+def test_emissions_against_expected(alice, gauge_controller, liquidity_gauge, root_gauge, token):
     gauge_controller.add_type("Test", 10 ** 18, {"from": alice})
     gauge_controller.add_gauge(liquidity_gauge, 0, 0, {"from": alice})
     gauge_controller.add_gauge(root_gauge, 0, 1, {"from": alice})
 
     chain.mine(timedelta=WEEK)
 
-
-@pytest.mark.skip_coverage
-def test_relative_weight_write(alice, chain, gauge_controller, liquidity_gauge, root_gauge, token):
     rate = token.rate()
     total_emissions = 0
     assert rate > 0
 
+    # 110 weeks ensures we see 2 reductions in the rate
     for i in range(1, 110):
-        # 110 weeks ensures we see 2 reductions in the rate
-        root_gauge.checkpoint()
-        new_emissions = root_gauge.emissions() - total_emissions
-        expected = rate * WEEK // i
 
+        this_week = chain[-1].timestamp // WEEK * WEEK
+        next_week = this_week + WEEK
+        start_epoch_time = root_gauge.start_epoch_time()
+        future_epoch_time = start_epoch_time + YEAR
+
+        # calculate the expected emissions, and checkpoint to update actual emissions
+        if next_week > future_epoch_time:
+            expected = rate * (future_epoch_time - this_week) // i
+            root_gauge.checkpoint()
+            rate = token.rate()
+            expected += rate * (next_week - future_epoch_time) // i
+        else:
+            expected = rate * WEEK // i
+            root_gauge.checkpoint()
+
+        # actual emissions should equal expected emissions
+        new_emissions = root_gauge.emissions() - total_emissions
         assert math.isclose(new_emissions, expected)
 
         total_emissions += new_emissions
-        rate = token.rate()
 
-        # increaseing the gauge weight on `liquidity_gauge` each week reducees
+        # increasing the gauge weight on `liquidity_gauge` each week reducees
         # the expected emission for `root_gauge` in the following week
         gauge_controller.change_gauge_weight(liquidity_gauge, i, {"from": alice})
         chain.mine(timedelta=WEEK)
+
+        assert rate == token.rate()
+
+
+@pytest.mark.skip_coverage
+def test_emissions_against_other_gauge(
+    alice, mock_lp_token, gauge_controller, liquidity_gauge, root_gauge
+):
+    gauge_controller.add_type("Test", 10 ** 18, {"from": alice})
+    gauge_controller.add_gauge(liquidity_gauge, 0, 1, {"from": alice})
+    gauge_controller.add_gauge(root_gauge, 0, 1, {"from": alice})
+
+    # alice is the only staker in `liquidity_gauge`
+    mock_lp_token.approve(liquidity_gauge, 2 ** 256 - 1, {"from": alice})
+    tx = liquidity_gauge.deposit(100000, {"from": alice})
+
+    # sleep until the start of the next epoch week
+    chain.mine(timestamp=(tx.timestamp // WEEK + 1) * WEEK)
+
+    # 110 weeks ensures we see 2 reductions in the rate
+    for i in range(1, 110):
+        # checkpointing the root gauge mints all the allocated emissions for the next week
+        tx = root_gauge.checkpoint()
+        emissions = root_gauge.emissions()
+
+        # now we time travel one week, and get the claimable rewards from the regular gauge
+        chain.mine(timestamp=(tx.timestamp // WEEK + 1) * WEEK)
+        claimable = liquidity_gauge.claimable_tokens(alice, {"from": alice}).return_value
+
+        # root gauge emissions should be equal to regular gauge claimable amount
+        assert math.isclose(emissions, claimable, rel_tol=1e-6)

--- a/tests/unitary/Sidechain/test_sending_to_bridge.py
+++ b/tests/unitary/Sidechain/test_sending_to_bridge.py
@@ -9,7 +9,7 @@ def test_anyswap_root_gauge_transfer_crv(alice, chain, gauge_controller, anyswap
     gauge_controller.add_type("Test", 10 ** 18, {"from": alice})
     gauge_controller.add_gauge(anyswap_root_gauge, 0, 1, {"from": alice})
 
-    chain.mine(timedelta=WEEK)
+    chain.mine(timedelta=2 * WEEK)
 
     amount = token.rate() * WEEK
 
@@ -28,7 +28,7 @@ def test_polygon_root_gauge_transfer_crv(alice, chain, gauge_controller, polygon
     gauge_controller.add_type("Test", 10 ** 18, {"from": alice})
     gauge_controller.add_gauge(polygon_root_gauge, 0, 1, {"from": alice})
 
-    chain.mine(timedelta=WEEK)
+    chain.mine(timedelta=2 * WEEK)
 
     amount = token.rate() * WEEK
 
@@ -60,7 +60,7 @@ def test_xdai_root_gauge_transfer_crv(alice, chain, gauge_controller, xdai_root_
     gauge_controller.add_type("Test", 10 ** 18, {"from": alice})
     gauge_controller.add_gauge(xdai_root_gauge, 0, 1, {"from": alice})
 
-    chain.mine(timedelta=WEEK)
+    chain.mine(timedelta=2 * WEEK)
 
     amount = token.rate() * WEEK
 

--- a/tests/unitary/Sidechain/test_sending_to_bridge.py
+++ b/tests/unitary/Sidechain/test_sending_to_bridge.py
@@ -1,6 +1,6 @@
-from hexbytes import HexBytes
+from brownie import ETH_ADDRESS, web3
 from brownie.convert import to_bytes
-from brownie import web3, ETH_ADDRESS
+from hexbytes import HexBytes
 
 WEEK = 86400 * 7
 

--- a/tests/unitary/Sidechain/test_sending_to_bridge.py
+++ b/tests/unitary/Sidechain/test_sending_to_bridge.py
@@ -1,0 +1,86 @@
+from hexbytes import HexBytes
+from brownie.convert import to_bytes
+from brownie import web3, ETH_ADDRESS
+
+WEEK = 86400 * 7
+
+
+def test_anyswap_root_gauge_transfer_crv(alice, chain, gauge_controller, anyswap_root_gauge, token):
+    gauge_controller.add_type("Test", 10 ** 18, {"from": alice})
+    gauge_controller.add_gauge(anyswap_root_gauge, 0, 1, {"from": alice})
+
+    chain.mine(timedelta=WEEK)
+
+    amount = token.rate() * WEEK
+
+    tx = anyswap_root_gauge.checkpoint()
+
+    transfer_subcall = tx.subcalls[-1]
+
+    assert transfer_subcall["function"] == "transfer(address,uint256)"
+    assert transfer_subcall["to"] == token
+    assert list(transfer_subcall["inputs"].values()) == [ETH_ADDRESS, amount]
+
+    assert token.balanceOf(ETH_ADDRESS) == amount
+
+
+def test_polygon_root_gauge_transfer_crv(alice, chain, gauge_controller, polygon_root_gauge, token):
+    gauge_controller.add_type("Test", 10 ** 18, {"from": alice})
+    gauge_controller.add_gauge(polygon_root_gauge, 0, 1, {"from": alice})
+
+    chain.mine(timedelta=WEEK)
+
+    amount = token.rate() * WEEK
+
+    tx = polygon_root_gauge.checkpoint()
+
+    # since we use a raw call won't show up in subcalls but we can check the trace
+    # and values in memory at the time of the call
+    deposit_for_call_memory = list(filter(lambda t: t["op"] == "CALL", tx.trace))[-1]["memory"]
+    memory = HexBytes("".join(deposit_for_call_memory))
+    # our expectation of what should be at the end of memory
+    # mirror of what is in the source code
+    # pad the end with 28 empty bytes, because we have the fn selector at the beginning
+    expected_data = (
+        web3.keccak(text="depositFor(address,address,bytes)")[:4]
+        + to_bytes(HexBytes(polygon_root_gauge.address))
+        + to_bytes(HexBytes(token.address))
+        + to_bytes(96)
+        + to_bytes(32)
+        + to_bytes(amount)
+        + (0).to_bytes(28, "big")
+    )
+
+    data_length = len(expected_data)
+    # check that we are calling the bridge addr with the appropriate data
+    assert memory[-data_length:] == expected_data
+
+
+def test_xdai_root_gauge_transfer_crv(alice, chain, gauge_controller, xdai_root_gauge, token):
+    gauge_controller.add_type("Test", 10 ** 18, {"from": alice})
+    gauge_controller.add_gauge(xdai_root_gauge, 0, 1, {"from": alice})
+
+    chain.mine(timedelta=WEEK)
+
+    amount = token.rate() * WEEK
+
+    tx = xdai_root_gauge.checkpoint()
+
+    # since we use a raw call won't show up in subcalls but we can check the trace
+    # and values in memory at the time of the call
+    relay_tokens_call_memory = list(filter(lambda t: t["op"] == "CALL", tx.trace))[-1]["memory"]
+    memory = HexBytes("".join(relay_tokens_call_memory))
+    # our expectation of what should be at the end of memory
+    # mirror of what is in the source code
+    # pad the end with 28 empty bytes, because we have the fn selector at the beginning
+    expected_data = (
+        web3.keccak(text="relayTokens(address,address,uint256)")[:4]
+        + to_bytes(HexBytes(token.address))
+        + to_bytes(HexBytes(xdai_root_gauge.address))
+        + to_bytes(amount)
+        + (0).to_bytes(28, "big")
+    )
+
+    data_length = len(expected_data)
+    # check that we are calling the bridge addr with the appropriate data
+    assert memory[-data_length:] == expected_data


### PR DESCRIPTION
### What I did
1. Fix issues in the emission schedule for `RootChain` gauges:
  * The old logic was rolling the rate-change over until the start of the next epoch week, would could conflict with existing gauges and cause a revert due to exceeding `ERC20CRV.available_supply()`. In fixing I realized that we cannot rely on `ERC20CRV.rate` for the new rate because we are minting _ahead_ of schedule. The solution is to calculate the rate locally within the gauges, using the same maff as we use within `ERC20CRV`.
2. Increase test coverage.
  * Tests for weekly emissions of each new gauge. One test compares the amount of CRV minted against a calculation in python, another compares mint amounts between `RootChainGauge` and `LiquidityGauge`. Given identical weights, the gauges should mint identical amounts.
  * Tests around calls to the bridges. As we're working in a dev environment, the best we can do here is to examine the call trace and see that it correctly calls to the bridge.
3. Add an event to help track emissions.