### PR TITLE
Feat/anyswap checkpoint

### DIFF
--- a/contracts/gauges/sidechain/RootGaugeAnyswap.vy
+++ b/contracts/gauges/sidechain/RootGaugeAnyswap.vy
@@ -63,12 +63,18 @@ anyswap_bridge: public(address)
 
 
 @external
-def __init__(_minter: address, _admin: address, _anyswap_bridge: address):
+def __init__(
+    _minter: address,
+    _admin: address,
+    _anyswap_bridge: address,
+    _checkpoint_admin: address,
+):
     """
     @notice Contract constructor
     @param _minter Minter contract address
     @param _admin Admin who can kill the gauge
     @param _anyswap_bridge Address of the AnySwap bridge where CRV is transferred
+    @param _checkpoint_admin Address of the checkpoint admin
     """
 
     crv_token: address = Minter(_minter).token()
@@ -78,6 +84,7 @@ def __init__(_minter: address, _admin: address, _anyswap_bridge: address):
     self.crv_token = crv_token
     self.controller = Minter(_minter).controller()
     self.anyswap_bridge = _anyswap_bridge
+    self.checkpoint_admin = _checkpoint_admin
 
     # because we calculate the rate locally, this gauge cannot
     # be used prior to the start of the first emission period

--- a/tests/unitary/Sidechain/conftest.py
+++ b/tests/unitary/Sidechain/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from brownie import ETH_ADDRESS
+from brownie import ETH_ADDRESS, ZERO_ADDRESS
 
 
 @pytest.fixture(scope="module")
@@ -11,7 +11,7 @@ def _root_gauge_setup(token, minter, chain, alice):
 
 @pytest.fixture(scope="module")
 def anyswap_root_gauge(_root_gauge_setup, RootGaugeAnyswap, minter, alice):
-    return RootGaugeAnyswap.deploy(minter, alice, ETH_ADDRESS, {"from": alice})
+    return RootGaugeAnyswap.deploy(minter, alice, ETH_ADDRESS, ZERO_ADDRESS, {"from": alice})
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
### What I did
Allow setting the checkpoint admin while deploying `RootGaugeAnyswap`.  This saves us a 2nd transaction later.