### PR TITLE
Remove useless _voting_escrow read in kick

### DIFF
--- a/contracts/gauges/LiquidityGaugeV3.vy
+++ b/contracts/gauges/LiquidityGaugeV3.vy
@@ -485,7 +485,7 @@ def kick(addr: address):
     )
     _balance: uint256 = self.balanceOf[addr]
 
-    assert ERC20(self.voting_escrow).balanceOf(addr) == 0 or t_ve > t_last # dev: kick not allowed
+    assert ERC20(_voting_escrow).balanceOf(addr) == 0 or t_ve > t_last # dev: kick not allowed
     assert self.working_balances[addr] > _balance * TOKENLESS_PRODUCTION / 100  # dev: kick not needed
 
     self._checkpoint(addr)


### PR DESCRIPTION
`_voting_escrow` has already been read previously and wouldn't change in between, we can reeuse it safely