### PR TITLE
New parameters script

### DIFF
--- a/scripts/voting/new_parameters.py
+++ b/scripts/voting/new_parameters.py
@@ -4,7 +4,6 @@ from brownie import Contract, chain
 
 import scripts.voting.new_vote as vote
 
-
 # This script updates parameters of pools via 'new_vote.py'
 # Update all lines marked 'CHANGE'
 

--- a/scripts/voting/new_parameters.py
+++ b/scripts/voting/new_parameters.py
@@ -1,0 +1,228 @@
+from datetime import datetime
+
+from brownie import Contract, chain
+
+import scripts.voting.new_vote as vote
+
+
+# This script updates parameters of pools via 'new_vote.py'
+# Update all lines marked 'CHANGE'
+
+POOL_PROXY = "0xeCb456EA5365865EbAb8a2661B0c503410e9B347"
+FACTORY_PROXY = "0x8CF8Af108B3B46DDC6AD596aebb917E053F0D72b"
+REGISTRY = "0x90E00ACe148ca3b23Ac1bC8C240C2a7Dd9c2d7f5"
+
+ADMIN_ACTIONS_DELAY = 3 * 86400
+
+new_parameters = [  # CHANGE
+    # ("new_fee", pool: address, new_fee: int, new_admin_fee: int)
+    # ("ramp_A", pool: address, is_factory_pool: bool, new_A: int, future_time: int)
+    # ("new_parameters", pool: address, new_A: int, new_fee: int, new_admin_fee: int,
+    # min_asymmetry: int)
+]
+# Fetch contracts
+new_parameters = [(params[0], Contract(params[1]), *params[2:]) for params in new_parameters]
+logs = [[] for _ in range(len(new_parameters))]
+
+
+def main():
+    for i, params in enumerate(new_parameters):
+        if params[0] == "new_fee":
+            add_new_fee(i, *params[1:])
+        elif params[0] == "ramp_A":
+            add_ramp_A(i, *params[1:])
+        elif params[0] == "new_parameters":
+            add_new_parameters(i, *params[1:])
+        else:
+            raise ValueError(f"Unknown action: {params}")
+
+    vote.TARGET = vote.CURVE_DAO_PARAM
+    vote.DESCRIPTION = ""  # CHANGE
+    if False:  # CHANGE for prod
+        vote.make_vote(vote.SENDER)  # CHANGE
+        return
+    vote.simulate()
+
+    # Check every pool separately
+    check_new_fee()
+    check_ramp_A()
+    check_new_parameters()
+
+    check_all_params()
+    # Finally all set
+
+
+def add_new_fee(i: int, pool: Contract, new_fee: int, new_admin_fee: int):
+    vote.ACTIONS.append(
+        (POOL_PROXY, "commit_new_fee", pool.address, new_fee, new_admin_fee),
+    )
+    logs[i].extend(
+        [
+            f"Address: {pool.address}",
+            f"Pool: {Contract(REGISTRY).get_pool_name(pool)}",
+            f"Current fee: {pool.fee()}",
+            f"Current admin_fee: {pool.admin_fee()}",
+            "",
+        ]
+    )
+
+
+def check_new_fee():
+    for i, params in enumerate(new_parameters):
+        if params[0] == "new_fee":
+            chain.snapshot()
+            _, pool, new_fee, new_admin_fee = params
+
+            chain.sleep(ADMIN_ACTIONS_DELAY)
+            Contract(POOL_PROXY).apply_new_fee(params[1], {"from": vote.SENDER})
+
+            fee = pool.fee()
+            admin_fee = pool.admin_fee()
+
+            ts = chain.time()
+            logs[i].extend(
+                [
+                    datetime.fromtimestamp(ts).ctime() + f", ts: {ts}",
+                    f"New fee: {fee}",
+                    f"New admin_fee: {admin_fee}",
+                    "",
+                ]
+            )
+            print(*logs[i], "", sep="\n")
+
+            assert fee == new_fee
+            assert admin_fee == new_admin_fee
+
+            chain.revert()
+
+
+def add_ramp_A(i: int, pool: Contract, is_factory_pool: bool, new_A: int, future_time: int):
+    vote.ACTIONS.append(
+        (
+            FACTORY_PROXY if is_factory_pool else POOL_PROXY,
+            "ramp_A",
+            pool.address,
+            new_A,
+            future_time,
+        ),
+    )
+    logs[i].extend(
+        [
+            f"Address: {pool.address}",
+            f"Pool: {pool.name() if is_factory_pool else Contract(REGISTRY).get_pool_name(pool)}",
+            f"Current A: {pool.A()}",
+            f"Current initial_A: {getattr(pool, 'initial_A', lambda: None)()}",
+            f"Current future_A: {pool.future_A()}",
+            f"Ramping to {new_A} by {future_time}",
+            "",
+        ]
+    )
+
+
+def check_ramp_A():
+    for i, params in enumerate(new_parameters):
+        if params[0] == "ramp_A":
+            chain.snapshot()
+            _, pool, is_factory_pool, new_A, future_time = params
+
+            initial_time = pool.initial_A_time()
+            checks_num = 4
+            for c in range(checks_num + 1):
+                ts = ((checks_num - c) * initial_time + c * future_time) // checks_num
+                chain.mine(1, timestamp=ts)
+                logs[i].append(f"{datetime.fromtimestamp(ts).ctime()}, ts: {ts}, A: {pool.A()}")
+
+            print(*logs[i], "", "", sep="\n")
+            assert pool.A() == new_A
+            assert pool.future_A_time() == future_time
+
+            # Does not change after
+            chain.mine(1, 2 * future_time)
+            assert pool.A() == new_A
+
+            chain.revert()
+
+
+def add_new_parameters(
+    i: int, pool: Contract, new_A: int, new_fee: int, new_admin_fee: int, min_asymmetry: int
+):
+    vote.ACTIONS.append(
+        (
+            POOL_PROXY,
+            "commit_new_parameters",
+            pool.address,
+            new_A,
+            new_fee,
+            new_admin_fee,
+            min_asymmetry,
+        ),
+    )
+    logs[i].extend(
+        [
+            f"Address: {pool.address}",
+            f"Pool: {Contract(REGISTRY).get_pool_name(pool)}",
+            f"Current A: {pool.A()}",
+            f"Current fee: {pool.fee()}",
+            f"Current admin_fee: {pool.admin_fee()}",
+            "",
+        ]
+    )
+
+
+def check_new_parameters():
+    for i, params in enumerate(new_parameters):
+        if params[0] == "new_parameters":
+            chain.snapshot()
+            _, pool, new_A, new_fee, new_admin_fee, min_asymmetry = params
+
+            chain.sleep(ADMIN_ACTIONS_DELAY)
+            assert Contract(POOL_PROXY).min_asymmetries(pool) == min_asymmetry
+            Contract(POOL_PROXY).apply_new_parameters(pool, {"from": vote.SENDER})
+
+            A = pool.A()
+            fee = pool.fee()
+            admin_fee = pool.admin_fee()
+
+            ts = chain.time()
+            logs[i].extend(
+                [
+                    datetime.fromtimestamp(ts).ctime() + f", ts: {ts}",
+                    f"New A: {A}",
+                    f"New fee: {fee}",
+                    f"New admin_fee: {admin_fee}",
+                    "",
+                ]
+            )
+            print(*logs[i], "", sep="\n")
+
+            assert A == new_A
+            assert fee == new_fee
+            assert admin_fee == new_admin_fee
+
+            chain.revert()
+
+
+def check_all_params():
+    """ Extra check, that eventually all parameters are correct. """
+    chain.sleep(ADMIN_ACTIONS_DELAY)
+    for params in new_parameters:
+        if params[0] == "new_fee":
+            Contract(POOL_PROXY).apply_new_fee(params[1], {"from": vote.SENDER})
+        elif params[0] == "new_parameters":
+            Contract(POOL_PROXY).apply_new_parameters(params[1], {"from": vote.SENDER})
+
+    chain.mine(1, timestamp=chain.time() + 365 * 86400)
+    for params in new_parameters:
+        if params[0] == "new_fee":
+            _, pool, new_fee, new_admin_fee = params
+            assert pool.fee() == new_fee
+            assert pool.admin_fee() == new_admin_fee
+        elif params[0] == "ramp_A":
+            _, pool, _, new_A, _ = params
+            assert pool.A() == new_A
+        elif params[0] == "new_parameters":
+            _, pool, new_A, new_fee, new_admin_fee, _ = params
+            pool: Contract
+            assert pool.A() == new_A
+            assert pool.fee() == new_fee
+            assert pool.admin_fee() == new_admin_fee

--- a/scripts/voting/new_vote.py
+++ b/scripts/voting/new_vote.py
@@ -8,7 +8,7 @@ from brownie.convert import to_address
 warnings.filterwarnings("ignore")
 
 # this script is used to prepare, simulate and broadcast votes within Curve's DAO
-# modify the constants below according the the comments, and then use `simulate` in
+# modify the constants below according to the comments, and then use `simulate` in
 # a forked mainnet to verify the result of the vote prior to broadcasting on mainnet
 
 # addresses related to the DAO - these should not need modification
@@ -40,7 +40,7 @@ TARGET = CURVE_DAO_OWNERSHIP
 # address to create the vote from - you will need to modify this prior to mainnet use
 SENDER = accounts.at("0x9B44473E223f8a3c047AD86f387B80402536B029", force=True)
 
-# a list of calls to perform in the vote, formatted as a lsit of tuples
+# a list of calls to perform in the vote, formatted as a list of tuples
 # in the format (target, function name, *input args).
 #
 # for example, to call:
@@ -105,6 +105,7 @@ def make_vote(sender=SENDER):
 
 
 def simulate():
+    print(f"Simulating actions: {ACTIONS}")
     # fetch the top holders so we can pass the vote
     data = requests.get(
         f"https://api.ethplorer.io/getTopTokenHolders/{TARGET['token']}",


### PR DESCRIPTION
# What I did
Added script to change parameters for pools and factory pools. It simulates the vote and checks twice(separately and together) that all parameters will be set.  
Logs without transactions look like:
```
Address: 0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7
Pool: 3pool
Current fee: 3000000
Current admin_fee: 5000000000

Fri Jul 23 11:56:22 2021, ts: 1627030582
New fee: 4000000
New admin_fee: 6000000000


Address: 0x9547429C0e2c3A8B88C6833B58FCE962734C0E8C
Pool: Curve.fi Factory USD Metapool: DOLA 3CRV Curve Metapool
Current A: 10
Current initial_A: 1000
Current future_A: 1000
Ramping to 100 by 1627733950

Tue Jul 20 11:56:09 2021, ts: 1626771369, A: 10
Fri Jul 23 06:46:54 2021, ts: 1627012014, A: 32
Mon Jul 26 01:37:39 2021, ts: 1627252659, A: 54
Wed Jul 28 20:28:24 2021, ts: 1627493304, A: 77
Sat Jul 31 15:19:10 2021, ts: 1627733950, A: 100


Address: 0x79a8C46DeA5aDa233ABaFFD40F3A0A2B1e5A4F27
Pool: busd
Current A: 500
Current fee: 4000000
Current admin_fee: 5000000000

Fri Jul 23 11:56:23 2021, ts: 1627030583
New A: 501
New fee: 1284938
New admin_fee: 3248234878
```

# Test
I manually checked
```py
new_parameters = [  # CHANGE
    ("new_fee", "0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7", 4000000, 6000000000),  # 3pool
    ("new_parameters", "0x79a8C46DeA5aDa233ABaFFD40F3A0A2B1e5A4F27", 501, 1284938, 3248234878, 0),  # busd
    # aave fee can't be changed due to incompatible 'commit_new_fee'
    ("new_parameters", "0xA2B47E3D5c44877cca798226B7B8118F9BFb7A56", 299, 9843023, 4890047381, 1),  # compound
    # saave fee can't be changed due to incompatible 'commit_new_fee'
    ("new_fee", "0x2dded6Da1BF5DBdF597C45fcFaa3194e53EcfeAF", 9912039, 4666488277),  # ib
    ("new_fee", "0x93054188d876f558f4a66B2EF1d97d16eDf0895B", 1000000, 1000000000),  # ren
    ("new_fee", "0xc5424B857f758E906013F3555Dad202e4bdB4567", 1010101, 3333333333),  # seth
    ("new_fee", "0xDC24316b9AE028F1497c275EB9192a3Ea0f67022", 1234567, 8910111213),  # steth
    ("new_parameters", "0xA5407eAE9Ba41422680e2e00537571bcC53efBfD", 98, 9876543, 2100000000, 3),  # susd
    ("new_parameters", "0x45F783CCE6B7FF23B2ab2D70e416cdb7D6055f51", 404, 3000000, 5000000000, 0),  # y
    ("ramp_A", "0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7", False, 3000, 1626733950 + 1231441),  # 3pool
    ("ramp_A", "0xDeBF20617708857ebe4F679508E7b7863a8A8EeE", False, 1000, 1626733950 + 1298942),  # aave
    ("ramp_A", "0xEB16Ae0052ed37f479f7fe63849198Df1765a733", False, 10, 1626733950 + 1000000),  # saave
    ("ramp_A", "0x2dded6Da1BF5DBdF597C45fcFaa3194e53EcfeAF", False, 90, 1626733950 + 1000000),  # ib
    ("ramp_A", "0x93054188d876f558f4a66B2EF1d97d16eDf0895B", False, 123, 1626733950 + 1000000),  # ren
    ("ramp_A", "0xc5424B857f758E906013F3555Dad202e4bdB4567", False, 193, 1626733950 + 1000000),  # seth
    ("ramp_A", "0xDC24316b9AE028F1497c275EB9192a3Ea0f67022", False, 219, 1626733950 + 1234567),  # steth
    ("ramp_A", "0x9547429C0e2c3A8B88C6833B58FCE962734C0E8C", True, 100, 1626733950 + 1000000),  # metapool
    # ("new_fee", pool: address, new_fee: int, new_admin_fee: int)
    # ("ramp_A", pool: address, is_factory_pool: bool, new_A: int, future_time: int)
    # ("new_parameters", pool: address, new_A: int, new_fee: int, new_admin_fee: int,
    # min_asymmetry: int)
]
```
(all pools from https://www.cognitiveatom.com/curve/)