### PR TITLE
feat: add crypto factory lp burner

### DIFF
--- a/contracts/burners/eth/CryptoFactoryLPBurner.vy
+++ b/contracts/burners/eth/CryptoFactoryLPBurner.vy
@@ -1,0 +1,237 @@
+# @version 0.3.1
+"""
+@title Crypto Factory LP Burner
+@notice Withdraws Crypto LP tokens
+"""
+
+
+interface ERC20:
+    def transferFrom(_from: address, _to: address, _value: uint256) -> bool: nonpayable
+    def balanceOf(_owner: address) -> uint256: view
+    def decimals() -> uint256: view
+
+interface CurveToken:
+    def minter() -> address: view
+
+interface CryptoSwap:
+    def remove_liquidity(_amount: uint256, min_amounts: uint256[2],
+                         use_eth: bool = False, receiver: address = msg.sender): nonpayable
+    def remove_liquidity_one_coin(token_amount: uint256, i: uint256, min_amount: uint256,
+                                  use_eth: bool = False, receiver: address = msg.sender) -> uint256: nonpayable
+    def coins(_i: uint256) -> address: view
+    def price_oracle() -> uint256: view
+    def lp_price() -> uint256: view
+
+
+priority: public(HashMap[address, uint256])
+
+receiver: public(address)
+recovery: public(address)
+is_killed: public(bool)
+
+owner: public(address)
+emergency_owner: public(address)
+future_owner: public(address)
+future_emergency_owner: public(address)
+
+
+@external
+def __init__(_receiver: address, _recovery: address, _owner: address, _emergency_owner: address):
+    """
+    @notice Contract constructor
+    @dev Unlike other burners, this contract may transfer tokens to
+         multiple addresses after the swap. Receiver addresses are
+         set by calling `set_swap_data` instead of setting it
+         within the constructor.
+    @param _recovery Address that tokens are transferred to during an
+                     emergency token recovery.
+    @param _owner Owner address. Can kill the contract, recover tokens
+                  and modify the recovery address.
+    @param _emergency_owner Emergency owner address. Can kill the contract
+                            and recover tokens.
+    """
+    self.receiver = _receiver
+    self.recovery = _recovery
+    self.owner = _owner
+    self.emergency_owner = _emergency_owner
+
+
+@payable
+@external
+def __default__():
+    # required to receive ether
+    pass
+
+
+@external
+def burn(_coin: address) -> bool:
+    """
+    @notice Convert `_coin` by removing liquidity and transfer to another burner
+    @param _coin Address of the coin being converted
+    @return bool success
+    """
+    assert not self.is_killed  # dev: is killed
+
+    # transfer coins from caller
+    amount: uint256 = ERC20(_coin).balanceOf(msg.sender)
+    if amount != 0:
+        ERC20(_coin).transferFrom(msg.sender, self, amount)
+
+    # get actual balance in case of transfer fee or pre-existing balance
+    amount = ERC20(_coin).balanceOf(self)
+
+    if amount != 0:
+        swap: address = CurveToken(_coin).minter()
+        coins: address[2] = [CryptoSwap(swap).coins(0), CryptoSwap(swap).coins(1)]
+        priorities: uint256[2] = [self.priority[coins[0]], self.priority[coins[1]]]
+        assert priorities[0] > 0 or priorities[1] > 0  # dev: unknown coins
+
+        i: uint256 = 2
+        if priorities[0] > priorities[1]:
+            i = 0
+        elif priorities[0] < priorities[1]:
+            i = 1
+
+        if i == 2:
+            # If both are equally prioritized, then remove both of them
+            CryptoSwap(swap).remove_liquidity(amount, [0, 0], True, self.receiver)
+        else:
+            min_amount: uint256 = amount * CryptoSwap(swap).lp_price() / 10 ** 18
+            if i == 1:
+                min_amount = min_amount * CryptoSwap(swap).price_oracle() / 10 ** 18
+            min_amount /= 10 ** (18 - ERC20(coins[i]).decimals())
+            min_amount = min_amount * 98 / 100
+
+            CryptoSwap(swap).remove_liquidity_one_coin(amount, i, min_amount, True, self.receiver)
+
+    return True
+
+
+@external
+def set_priority(_coin: address, _priority: uint256):
+    """
+    @notice Set priority of a coin
+    @dev Bigger value means higher priority
+    @param _coin Token address
+    @param _priority Token priority
+    """
+    assert msg.sender in [self.owner, self.emergency_owner]  # dev: only owner
+    self.priority[_coin] = _priority
+
+
+@external
+def set_many_priorities(_coins: address[8], _priorities: uint256[8]):
+    """
+    @notice Set priority of many coins
+    @dev Bigger value means higher priority
+    @param _coins Token addresses
+    @param _priorities Token priorities
+    """
+    assert msg.sender in [self.owner, self.emergency_owner]  # dev: only owner
+    for i in range(8):
+        coin: address = _coins[i]
+        if coin == ZERO_ADDRESS:
+            break
+        self.priority[coin] = _priorities[i]
+
+
+@external
+def recover_balance(_coin: address) -> bool:
+    """
+    @notice Recover ERC20 tokens from this contract
+    @dev Tokens are sent to the recovery address
+    @param _coin Token address
+    @return bool success
+    """
+    assert msg.sender in [self.owner, self.emergency_owner]  # dev: only owner
+
+    amount: uint256 = ERC20(_coin).balanceOf(self)
+    response: Bytes[32] = raw_call(
+        _coin,
+        _abi_encode(self.recovery, amount, method_id=method_id("transfer(address,uint256)")),
+        max_outsize=32,
+    )
+    if len(response) != 0:
+        assert convert(response, bool)
+
+    return True
+
+
+@external
+def set_recovery(_recovery: address) -> bool:
+    """
+    @notice Set the token recovery address
+    @param _recovery Token recovery address
+    @return bool success
+    """
+    assert msg.sender == self.owner  # dev: only owner
+    self.recovery = _recovery
+
+    return True
+
+
+@external
+def set_killed(_is_killed: bool) -> bool:
+    """
+    @notice Set killed status for this contract
+    @dev When killed, the `burn` function cannot be called
+    @param _is_killed Killed status
+    @return bool success
+    """
+    assert msg.sender in [self.owner, self.emergency_owner]  # dev: only owner
+    self.is_killed = _is_killed
+
+    return True
+
+
+
+@external
+def commit_transfer_ownership(_future_owner: address) -> bool:
+    """
+    @notice Commit a transfer of ownership
+    @dev Must be accepted by the new owner via `accept_transfer_ownership`
+    @param _future_owner New owner address
+    @return bool success
+    """
+    assert msg.sender == self.owner  # dev: only owner
+    self.future_owner = _future_owner
+
+    return True
+
+
+@external
+def accept_transfer_ownership() -> bool:
+    """
+    @notice Accept a transfer of ownership
+    @return bool success
+    """
+    assert msg.sender == self.future_owner  # dev: only owner
+    self.owner = msg.sender
+
+    return True
+
+
+@external
+def commit_transfer_emergency_ownership(_future_owner: address) -> bool:
+    """
+    @notice Commit a transfer of ownership
+    @dev Must be accepted by the new owner via `accept_transfer_ownership`
+    @param _future_owner New owner address
+    @return bool success
+    """
+    assert msg.sender == self.emergency_owner  # dev: only owner
+    self.future_emergency_owner = _future_owner
+
+    return True
+
+
+@external
+def accept_transfer_emergency_ownership() -> bool:
+    """
+    @notice Accept a transfer of ownership
+    @return bool success
+    """
+    assert msg.sender == self.future_emergency_owner  # dev: only owner
+    self.emergency_owner = msg.sender
+
+    return True

--- a/tests/fork/Burners/test_crypto_factory_lp_burner.py
+++ b/tests/fork/Burners/test_crypto_factory_lp_burner.py
@@ -1,0 +1,109 @@
+import brownie
+import pytest
+from brownie import ZERO_ADDRESS
+from brownie_tokens import MintableForkToken
+
+coins = {
+    "weth": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+    "yfi": "0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e",
+    "stg": "0xAf5191B0De278C7286d6C7CC6ab6BB8A73bA2Cd6",
+    "usdc": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    "btrfly": "0xC0d4Ceb216B3BA9C3701B291766fDCbA977ceC3A",
+}
+
+tokens = {
+    "yfieth": "0x29059568bB40344487d62f7450E78b8E6C74e0e5",
+    "stgusdc": "0xdf55670e27bE5cDE7228dD0A6849181891c9ebA1",
+    "ethbtrfly": "0xE160364FD8407FFc8b163e278300c6C5D18Ff61d",
+    "badgerwbtc": "0x137469B55D1f15651BA46A89D0588e97dD0B6562",
+}
+
+
+@pytest.fixture(scope="module")
+def burner(CryptoFactoryLPBurner, alice, receiver):
+    yield CryptoFactoryLPBurner.deploy(receiver, alice, alice, alice, {"from": alice})
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup(burner, alice):
+    prioritized = [coins["weth"], coins["usdc"], coins["btrfly"]]
+    priorities = [10, 10, 10]
+    burner.set_many_priorities(
+        prioritized + [ZERO_ADDRESS] * (8 - len(prioritized)),
+        priorities + [0] * (8 - len(priorities)),
+        {"from": alice},
+    )
+
+
+def test_first_coin(burner, alice, receiver):
+    token = MintableForkToken(tokens["yfieth"])
+    token.approve(burner, 2 ** 256 - 1, {"from": alice})
+    token._mint_for_testing(alice, 10 * 10 ** 18, {"from": alice})
+
+    burner.burn(token, {"from": alice})
+
+    first, second = MintableForkToken(coins["weth"]), MintableForkToken(coins["yfi"])
+    assert first.balanceOf(receiver) == 0
+    assert receiver.balance() > 0
+    assert second.balanceOf(receiver) == 0
+
+
+def test_second_coin(burner, alice, receiver):
+    token = MintableForkToken(tokens["stgusdc"])
+    token.approve(burner, 2 ** 256 - 1, {"from": alice})
+    token._mint_for_testing(alice, 10 * 10 ** 18, {"from": alice})
+
+    burner.burn(token, {"from": alice})
+
+    first, second = MintableForkToken(coins["stg"]), MintableForkToken(coins["usdc"])
+    assert first.balanceOf(receiver) == 0
+    assert second.balanceOf(receiver) > 0
+
+
+def test_both_coins(burner, alice, receiver):
+    token = MintableForkToken(tokens["ethbtrfly"])
+    token.approve(burner, 2 ** 256 - 1, {"from": alice})
+    token._mint_for_testing(alice, 10 * 10 ** 18, {"from": alice})
+
+    burner.burn(token, {"from": alice})
+
+    first, second = MintableForkToken(coins["weth"]), MintableForkToken(coins["btrfly"])
+    assert first.balanceOf(receiver) == 0
+    assert receiver.balance() > 0
+    assert second.balanceOf(receiver) > 0
+
+
+def test_set_priority(burner, alice):
+    coin = coins["weth"]
+    assert burner.priority(coin) == 10
+    burner.set_priority(coin, 0, {"from": alice})
+    assert burner.priority(coin) == 0
+
+
+@pytest.mark.parametrize("i", [0, 1])
+def test_more_prioritized(burner, alice, receiver, i):
+    token = MintableForkToken(tokens["ethbtrfly"])
+    token.approve(burner, 2 ** 256 - 1, {"from": alice})
+    token._mint_for_testing(alice, 10 * 10 ** 18, {"from": alice})
+
+    first, second = MintableForkToken(coins["weth"]), MintableForkToken(coins["btrfly"])
+    burner.set_priority(first if i == 0 else second, 100, {"from": alice})
+
+    burner.burn(token, {"from": alice})
+
+    assert first.balanceOf(receiver) == 0
+    if i == 0:
+        assert receiver.balance() > 0
+        assert second.balanceOf(receiver) == 0
+    else:
+        assert receiver.balance() == 0
+        assert second.balanceOf(receiver) > 0
+
+
+def test_unkown_priorities(burner, alice):
+    token = MintableForkToken(tokens["badgerwbtc"])
+    token.approve(burner, 2 ** 256 - 1, {"from": alice})
+    token._mint_for_testing(alice, 10 * 10 ** 18, {"from": alice})
+
+    with brownie.reverts():
+        burner.burn(token, {"from": alice})

--- a/tests/fork/Burners/test_crypto_factory_lp_burner.py
+++ b/tests/fork/Burners/test_crypto_factory_lp_burner.py
@@ -50,7 +50,8 @@ def test_set_receivers(burner, alice, bob):
     coins_with_custom_receiver = [coins["weth"], coins["usdc"]]
     burner.set_many_receivers(
         coins_with_custom_receiver + [ZERO_ADDRESS] * (8 - len(coins_with_custom_receiver)),
-        [bob] * len(coins_with_custom_receiver) + [ZERO_ADDRESS] * (8 - len(coins_with_custom_receiver)),
+        [bob] * len(coins_with_custom_receiver)
+        + [ZERO_ADDRESS] * (8 - len(coins_with_custom_receiver)),
         {"from": alice},
     )
     for coin in coins_with_custom_receiver:


### PR DESCRIPTION
Factory Crypto LP Burner

- remove the most prioritised coin with 2% slippage according to price_oracle
- both coins are equally prioritised => remove both of them to save ratio
- revert if both coins have no priority