### PR TITLE
fix: crypto burners

### DIFF
--- a/contracts/burners/eth/CryptoFactoryLPBurner.vy
+++ b/contracts/burners/eth/CryptoFactoryLPBurner.vy
@@ -1,4 +1,4 @@
-# @version 0.3.1
+# @version 0.3.7
 """
 @title Crypto Factory LP Burner
 @notice Withdraws Crypto LP tokens
@@ -27,10 +27,14 @@ interface PoolProxy:
     def burners(_coin: address) -> address: view
 
 
+BPS: constant(uint256) = 10000
+
+slippage_of: public(HashMap[address, uint256])
 priority_of: public(HashMap[address, uint256])
 receiver_of: public(HashMap[address, address])
 
 pool_proxy: public(address)
+slippage: public(uint256)
 receiver: public(address)
 recovery: public(address)
 is_killed: public(bool)
@@ -66,6 +70,10 @@ def __init__(_pool_proxy: address, _receiver: address, _recovery: address, _owne
     self.emergency_owner = _emergency_owner
     self.manager = msg.sender
 
+    self.slippage = 100  # 1%
+    # 3crv to fee_distributor
+    self.receiver_of[0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490] = 0xA464e6DCda8AC41e03616F95f4BC98a13b8922Dc
+
 
 @internal
 def _burn(_coin: address, _amount: uint256):
@@ -80,6 +88,10 @@ def _burn(_coin: address, _amount: uint256):
     elif priorities[0] < priorities[1]:
         i = 1
 
+    slippage: uint256 = self.slippage_of[_coin]
+    if slippage == 0:
+        slippage = self.slippage
+
     if i == 2:
         # If both are equally prioritized, then remove both of them
         CryptoSwap(swap).remove_liquidity(_amount, [0, 0], True, self.receiver)
@@ -88,7 +100,7 @@ def _burn(_coin: address, _amount: uint256):
         if i == 1:
             min_amount = min_amount * 10 ** 18 / CryptoSwap(swap).price_oracle()
         min_amount /= 10 ** (18 - ERC20(coins[i]).decimals())
-        min_amount = min_amount * 98 / 100
+        min_amount -= min_amount * slippage / BPS
 
         receiver: address = self.receiver_of[coins[i]]
         if receiver == ZERO_ADDRESS:
@@ -139,14 +151,14 @@ def burn_amount(_coin: address, _amount_to_burn: uint256):
 
 
 @external
-def set_priority(_coin: address, _priority: uint256):
+def set_priority_of(_coin: address, _priority: uint256):
     """
     @notice Set priority of a coin
     @dev Bigger value means higher priority
     @param _coin Token address
     @param _priority Token priority
     """
-    assert msg.sender == self.manager  # dev: only owner
+    assert msg.sender == self.manager  # dev: only manager
     self.priority_of[_coin] = _priority
 
 
@@ -158,7 +170,7 @@ def set_many_priorities(_coins: address[8], _priorities: uint256[8]):
     @param _coins Token addresses
     @param _priorities Token priorities
     """
-    assert msg.sender == self.manager  # dev: only owner
+    assert msg.sender == self.manager  # dev: only manager
     for i in range(8):
         coin: address = _coins[i]
         if coin == ZERO_ADDRESS:
@@ -167,7 +179,48 @@ def set_many_priorities(_coins: address[8], _priorities: uint256[8]):
 
 
 @external
-def set_receiver(_coin: address, _receiver: address):
+def set_slippage_of(_coin: address, _slippage: uint256):
+    """
+    @notice Set custom slippage limit of a coin
+    @dev Using self.slippage by default
+    @param _coin Token address
+    @param _slippage Slippage in bps for pool of token
+    """
+    assert msg.sender == self.manager  # dev: only manager
+    assert _slippage <= BPS  # dev: slippage too high
+    self.slippage_of[_coin] = _slippage
+
+
+@external
+def set_many_slippages(_coins: address[8], _slippages: uint256[8]):
+    """
+    @notice Set custom slippage limit of a coin
+    @dev Using self.slippage by default
+    @param _coins Token addresses
+    @param _slippages Slippages in bps for each pool of token
+    """
+    assert msg.sender == self.manager  # dev: only manager
+    for i in range(8):
+        coin: address = _coins[i]
+        if coin == ZERO_ADDRESS:
+            break
+        assert _slippages[i] <= BPS  # dev: slippage too high
+        self.slippage_of[coin] = _slippages[i]
+
+
+@external
+def set_slippage(_slippage: uint256):
+    """
+    @notice Set default slippage parameter
+    @param _slippage Slippage value in bps
+    """
+    assert msg.sender in [self.owner, self.emergency_owner]  # dev: only owner
+    assert _slippage <= BPS  # dev: slippage too high
+    self.slippage = _slippage
+
+
+@external
+def set_receiver_of(_coin: address, _receiver: address):
     """
     @notice Set receiver of a coin
     @dev Using self.receiver by default
@@ -192,6 +245,16 @@ def set_many_receivers(_coins: address[8], _receivers: address[8]):
         if coin == ZERO_ADDRESS:
             break
         self.receiver_of[coin] = _receivers[i]
+
+
+@external
+def set_receiver(_receiver: address):
+    """
+    @notice Set default receiver
+    @param _receiver Address of default receiver
+    """
+    assert msg.sender in [self.owner, self.emergency_owner]  # dev: only owner
+    self.receiver = _receiver
 
 
 @external

--- a/contracts/burners/eth/CryptoFactoryLPBurner.vy
+++ b/contracts/burners/eth/CryptoFactoryLPBurner.vy
@@ -86,7 +86,7 @@ def _burn(_coin: address, _amount: uint256):
     else:
         min_amount: uint256 = _amount * CryptoSwap(swap).lp_price() / 10 ** 18
         if i == 1:
-            min_amount = min_amount * CryptoSwap(swap).price_oracle() / 10 ** 18
+            min_amount = min_amount * 10 ** 18 / CryptoSwap(swap).price_oracle()
         min_amount /= 10 ** (18 - ERC20(coins[i]).decimals())
         min_amount = min_amount * 98 / 100
 

--- a/contracts/burners/eth/CryptoLPBurner.vy
+++ b/contracts/burners/eth/CryptoLPBurner.vy
@@ -2,6 +2,7 @@
 """
 @title Crypto LP Burner
 @notice Withdraws Crypto LP tokens
+@dev Fixed indexes
 """
 
 from vyper.interfaces import ERC20
@@ -93,9 +94,9 @@ def burn(_coin: address) -> bool:
         coins: address[8] = Registry(registry).get_coins(swap)
         # remove liquidity and pass to the next burner
 
-        if coins[3] == ZERO_ADDRESS:
+        if coins[2] == ZERO_ADDRESS:
             CryptoSwap2(swap).remove_liquidity(amount, [0, 0])
-        elif coins[4] == ZERO_ADDRESS:
+        elif coins[3] == ZERO_ADDRESS:
             CryptoSwap3(swap).remove_liquidity(amount, [0, 0, 0])
         else:
             CryptoSwap4(swap).remove_liquidity(amount, [0, 0, 0, 0])

--- a/tests/fork/Burners/test_crypto_factory_lp_burner.py
+++ b/tests/fork/Burners/test_crypto_factory_lp_burner.py
@@ -8,13 +8,13 @@ coins = {
     "yfi": "0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e",
     "stg": "0xAf5191B0De278C7286d6C7CC6ab6BB8A73bA2Cd6",
     "usdc": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-    "btrfly": "0xC0d4Ceb216B3BA9C3701B291766fDCbA977ceC3A",
+    "btrfly": "0xc55126051B22eBb829D00368f4B12Bde432de5Da",
 }
 
 tokens = {
     "yfieth": "0x29059568bB40344487d62f7450E78b8E6C74e0e5",
     "stgusdc": "0xdf55670e27bE5cDE7228dD0A6849181891c9ebA1",
-    "ethbtrfly": "0xE160364FD8407FFc8b163e278300c6C5D18Ff61d",
+    "btrflyeth": "0x7483Dd57f6488b0e194A151C57Df6Ec85C00aCE9",
     "badgerwbtc": "0x137469B55D1f15651BA46A89D0588e97dD0B6562",
 }
 
@@ -47,27 +47,50 @@ def setup(burner, alice):
     )
 
 
-def test_set_priority(burner, alice):
+def test_set_slippage(burner, alice, bob):
+    assert burner.slippage() == 100
+    burner.set_slippage(200, {"from": alice})
+    assert burner.slippage() == 200
+    with brownie.reverts():  # only owner
+        burner.set_slippage(10, {"from": bob})
+
+
+def test_set_priority(burner, alice, bob):
     coin = coins["weth"]
     assert burner.priority_of(coin) == 10
-    burner.set_priority(coin, 0, {"from": alice})
+    burner.set_priority_of(coin, 0, {"from": alice})
     assert burner.priority_of(coin) == 0
+    with brownie.reverts():  # only manager
+        burner.set_priority_of(coin, 1, {"from": bob})
 
 
-def test_set_receivers(burner, alice, bob):
+def test_set_receivers(burner, alice, bob, pool_proxy, receiver):
     assert burner.receiver_of(coins["weth"]) == ZERO_ADDRESS
-    burner.set_receiver(coins["weth"], bob)
+    burner.set_receiver_of(coins["weth"], bob)
     assert burner.receiver_of(coins["weth"]) == bob.address
+    with brownie.reverts():  # only admin
+        burner.set_receiver_of(coins["weth"], bob, {"from": bob})
 
     coins_with_custom_receiver = [coins["weth"], coins["usdc"]]
     burner.set_many_receivers(
         coins_with_custom_receiver + [ZERO_ADDRESS] * (8 - len(coins_with_custom_receiver)),
-        [bob] * len(coins_with_custom_receiver)
-        + [ZERO_ADDRESS] * (8 - len(coins_with_custom_receiver)),
+        [pool_proxy] * len(coins_with_custom_receiver) + [ZERO_ADDRESS] * (8 - len(coins_with_custom_receiver)),
         {"from": alice},
     )
     for coin in coins_with_custom_receiver:
-        assert burner.receiver_of(coin) == bob.address
+        assert burner.receiver_of(coin) == pool_proxy
+    with brownie.reverts():  # only admin
+        burner.set_many_receivers(
+            [coins["weth"]] + [ZERO_ADDRESS] * (8 - 1),
+            [bob] + [ZERO_ADDRESS] * (8 - 1),
+            {"from": bob},
+        )
+
+    assert burner.receiver() == receiver
+    burner.set_receiver(pool_proxy)
+    assert burner.receiver() == pool_proxy
+    with brownie.reverts():  # only admin
+        burner.set_receiver(bob, {"from": bob})
 
 
 @pytest.mark.parametrize("final_receiver", ["receiver", "bob"])
@@ -79,7 +102,7 @@ def test_first_coin(burner, alice, bob, receiver, final_receiver):
 
     first, second = MintableForkToken(coins["weth"]), MintableForkToken(coins["yfi"])
     if final_receiver == "bob":
-        burner.set_receiver(first, bob, {"from": alice})
+        burner.set_receiver_of(first, bob, {"from": alice})
     burner.burn(token, {"from": alice})
 
     for acc in [bob, receiver]:
@@ -106,7 +129,7 @@ def test_second_coin(burner, alice, receiver):
 
 
 def test_both_coins(burner, alice, receiver):
-    token = MintableForkToken(tokens["ethbtrfly"])
+    token = MintableForkToken(tokens["btrflyeth"])
     token.approve(burner, 2 ** 256 - 1, {"from": alice})
     token._mint_for_testing(alice, 10 * 10 ** 18, {"from": alice})
 
@@ -120,12 +143,12 @@ def test_both_coins(burner, alice, receiver):
 
 @pytest.mark.parametrize("i", [0, 1])
 def test_more_prioritized(burner, alice, receiver, i):
-    token = MintableForkToken(tokens["ethbtrfly"])
+    token = MintableForkToken(tokens["btrflyeth"])
     token.approve(burner, 2 ** 256 - 1, {"from": alice})
     token._mint_for_testing(alice, 10 * 10 ** 18, {"from": alice})
 
     first, second = MintableForkToken(coins["weth"]), MintableForkToken(coins["btrfly"])
-    burner.set_priority(first if i == 0 else second, 100, {"from": alice})
+    burner.set_priority_of(first if i == 0 else second, 100, {"from": alice})
 
     burner.burn(token, {"from": alice})
 
@@ -147,7 +170,7 @@ def test_burn_amount(burner, pool_proxy, alice, receiver):
     amount = token.balanceOf(pool_proxy)
 
     burner.burn_amount(token, amount // 2, {"from": alice})
-    assert token.balanceOf(burner) == amount // 2
+    assert token.balanceOf(burner) == amount - amount // 2
 
     first, second = MintableForkToken(coins["stg"]), MintableForkToken(coins["usdc"])
     assert first.balanceOf(receiver) == 0
@@ -177,7 +200,7 @@ def test_manager(burner, alice, bob, charlie):
     assert burner.future_manager() == bob
 
     # Manager has access
-    burner.set_priority(coins["weth"], 0, {"from": bob})
+    burner.set_priority_of(coins["weth"], 0, {"from": bob})
     assert burner.priority_of(coins["weth"]) == 0
     burner.set_many_priorities(
         [coins["weth"], coins["usdc"]] + [ZERO_ADDRESS] * 6,
@@ -192,9 +215,17 @@ def test_manager(burner, alice, bob, charlie):
 
     # Old manager does not have access
     with brownie.reverts():
-        burner.set_priority(coins["weth"], 0, {"from": bob})
+        burner.set_priority_of(coins["weth"], 0, {"from": bob})
     with brownie.reverts():
         burner.set_many_priorities(
+            [coins["weth"], coins["usdc"]] + [ZERO_ADDRESS] * 6,
+            [1, 2] + [0] * 6,
+            {"from": bob},
+        )
+    with brownie.reverts():
+        burner.set_slippage_of(coins["weth"], 0, {"from": bob})
+    with brownie.reverts():
+        burner.set_many_slippages(
             [coins["weth"], coins["usdc"]] + [ZERO_ADDRESS] * 6,
             [1, 2] + [0] * 6,
             {"from": bob},

--- a/tests/fork/Burners/test_crypto_factory_lp_burner.py
+++ b/tests/fork/Burners/test_crypto_factory_lp_burner.py
@@ -74,7 +74,8 @@ def test_set_receivers(burner, alice, bob, pool_proxy, receiver):
     coins_with_custom_receiver = [coins["weth"], coins["usdc"]]
     burner.set_many_receivers(
         coins_with_custom_receiver + [ZERO_ADDRESS] * (8 - len(coins_with_custom_receiver)),
-        [pool_proxy] * len(coins_with_custom_receiver) + [ZERO_ADDRESS] * (8 - len(coins_with_custom_receiver)),
+        [pool_proxy] * len(coins_with_custom_receiver)
+        + [ZERO_ADDRESS] * (8 - len(coins_with_custom_receiver)),
         {"from": alice},
     )
     for coin in coins_with_custom_receiver:


### PR DESCRIPTION
## Crypto LP burner
Wrong indexes of coins were used to determine the type of crypto pool. Fixed that and added a comment in head of the contract.

## Crypto Factory Burner
Inverse price was used to calculate slippage. Added custom slippage.